### PR TITLE
Added new association structures

### DIFF
--- a/R/stan_jm.R
+++ b/R/stan_jm.R
@@ -16,15 +16,15 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
-#' Bayesian joint models for longitudinal and time-to-event data via Stan
+#' Bayesian joint longitudinal and time-to-event models via Stan
 #' 
-#' Bayesian inference for shared parameter joint models for longitudinal 
-#' and time-to-event (e.g. survival) data.
+#' Fits a shared parameter joint model for longitudinal and time-to-event 
+#' (e.g. survival) data under a Bayesian framework using Stan.
 #' 
 #' @param formulaLong A two-sided linear formula object describing both the 
-#'   fixed-effect and group-specific parts of the longitudinal submodel  
+#'   fixed-effects and random-effects parts of the longitudinal submodel  
 #'   (see \code{\link[lme4]{glmer}} for details). For a multivariate joint 
-#'   model (i.e. more than one longitudinal outcome) this should 
+#'   model (i.e. more than one longitudinal marker) this should 
 #'   be a list of such formula objects, with each element
 #'   of the list providing the formula for one of the longitudinal submodels.
 #' @param dataLong A data frame containing the variables specified in
@@ -53,20 +53,22 @@
 #'   family for one of the longitudinal submodels.
 #' @param assoc A character string or character vector specifying the joint
 #'   model association structure. Possible association structures that can
-#'   be used include: "etavalue" (the default); "etaslope"; "muvalue"; 
-#'   "shared_b"; "shared_coef"; or "null". These are described in the 
+#'   be used include: "etavalue" (the default); "etaslope"; "etalag"; "etaauc; "muvalue"; 
+#'   "muslope"; "mulag"; "muauc"; "shared_b"; "shared_coef"; or "null". 
+#'   These are described in the 
 #'   \strong{Details} section below. For a multivariate joint model, 
-#'   different association structures can optionally be used for each 
-#'   longitudinal submodel by specifying a list of character vectors, with
-#'   each element of the list specifying the desired association structure
-#'   for one of the longitudinal submodels. Specifying \code{assoc = NULL}
+#'   different association structures can optionally be used for 
+#'   each longitudinal submodel by specifying a list of character
+#'   vectors, with each element of the list specifying the desired association 
+#'   structure for one of the longitudinal submodels. Specifying \code{assoc = NULL}
 #'   will fit a joint model with no association structure (equivalent  
 #'   to fitting separate longitudinal and time-to-event models). Also see the
-#'   \strong{Details} and \strong{Examples} sections below.
+#'   \strong{Examples} section below.
 #' @param base_haz A character string indicating which baseline hazard to use
 #'   for the event submodel. Options are a Weibull baseline hazard
-#'   (\code{"weibull"}, the default), a approximation using B-splines  
-#'   (\code{"bs"}), or a piecewise constant baseline hazard (\code{"piecewise"}).
+#'   (\code{"weibull"}, the default), a B-splines approximation estimated 
+#'   for the log baseline hazard (\code{"bs"}), or a piecewise
+#'   constant baseline hazard (\code{"piecewise"}).
 #' @param df An optional positive integer specifying the degrees of freedom 
 #'   for the B-splines if \code{base_haz = "bs"}, or the number of
 #'   intervals used for the piecewise constant baseline hazard if 
@@ -79,10 +81,10 @@
 #'   default is to use \code{df - 4} knots if \code{base_haz = "bs"},
 #'   or \code{df - 1} knots if \code{base_haz = "piecewise"}, which are
 #'   placed at equally spaced percentiles of the distribution of
-#'   observed event times (not including the censoring times).
+#'   observed event times.
 #' @param quadnodes The number of nodes to use for the Gauss-Kronrod quadrature
-#'   that is used to evaluate the cumulative hazard in the likelihood function
-#'   for the event submodel. Options are 15 (the default), 11 or 7.
+#'   that is used to evaluate the cumulative hazard in the likelihood function. 
+#'   Options are 15 (the default), 11 or 7.
 #' @param subsetLong,subsetEvent Same as subset in \code{\link[stats]{glm}}.
 #'   However, if fitting a multivariate joint model and a list of data frames 
 #'   is provided in \code{dataLong} then a corresponding list of subsets 
@@ -96,7 +98,7 @@
 #'   the second containing the corresponding weights. The data frame should only
 #'   have one row for each individual; that is, weights should be constant 
 #'   within individuals.
-#' @param offset Not yet implemented. Same as \code{\link[stats]{glm}}. 
+#' @param offset Not currently implemented. Same as \code{\link[stats]{glm}}. 
 #' @param centreLong,centreEvent A logical specifying whether the predictor
 #'   matrix for the longitudinal submodel(s) or event submodel should be 
 #'   centred. 
@@ -113,8 +115,7 @@
 #'   are those described for \code{\link[rstan]{stan}}.     
 #' @param ... Further arguments passed to 
 #'   \code{\link[rstan]{sampling}} (e.g. \code{iter}, \code{chains}, 
-#'   \code{cores}, etc.) or to \code{\link[rstan]{vb}} (if algorithm is 
-#'   \code{"meanfield"} or \code{"fullrank"}).
+#'   \code{cores}, etc.).
 #' @param priorLong,priorEvent,priorAssoc The prior distributions for the 
 #'   regression coefficients in the longitudinal submodel(s), event submodel,
 #'   and the association parameter(s). 
@@ -137,7 +138,7 @@
 #'   dispersion parameters in the longitudinal submodel(s) set 
 #'   \code{priorLong_ops} to \code{NULL}. To omit a prior on the 
 #'   Weibull shape parameter (if \code{base_haz = "weibull"}) or the
-#'   baseline hazard coefficients (if \code{base_haz = "bs"} or \code{base_haz = "bs"}) set 
+#'   spline coefficients (if \code{base_haz = "bs"}) set 
 #'   \code{priorEvent_ops} to \code{NULL}. Otherwise see \code{\link{priors}}. 
 #' @param prior_covariance Cannot be \code{NULL}; see \code{\link{decov}} for
 #'   more information about the default arguments.
@@ -152,39 +153,36 @@
 #' @param algorithm Character string (possibly abbreviated) indicating the 
 #'   estimation approach to use. Currently, only "sampling" (for MCMC) is 
 #'   allowed.
+#' @param debug Should not be used. This is used in package development to
+#'   help identify the location of bugs in the Stan code. When set to 
+#'   \code{TRUE}, the Stan file executes several print statements which 
+#'   can help to identify the location of bugs or numerical instabilities.  
 #'   
-#' @details The \code{stan_jm} function can be used to fit a shared parameter
-#'   joint models for longitudinal and time-to-event data under a Bayesian 
-#'   framework via Stan. \cr
+#' @details The \code{stan_jm} function can be used to fit a joint model (also 
+#'   known as a shared parameter model) for longitudinal and time-to-event data 
+#'   under a Bayesian framework. 
+#'   The joint model may be univariate (with only one longitudinal submodel) or
+#'   multivariate (with more than one longitudinal submodel). Multi-level 
+#'   clustered data are allowed (e.g. patients within clinics), provided that the
+#'   individual (e.g. patient) is the lowest level of clustering. The underlying
+#'   estimation is carried out using the Bayesian C++ package Stan 
+#'   (\url{http://mc-stan.org/}). \cr
+#'   \cr 
+#'   For the longitudinal submodel a generalised linear mixed model is assumed 
+#'   with any of the \code{\link[stats]{family}} choices allowed by 
+#'   \code{\link[lme4]{glmer}}. \cr
 #'   \cr
-#'   Both univariate (one longitudinal outcome) and multivariate (more than 
-#'   one longitudinal outcome) joint models can be estimated. The estimated 
-#'   longitudinal submodel(s) are specified as a (multivariate) generalised 
-#'   linear mixed effects model with any of the \code{\link[stats]{family}} 
-#'   choices allowed by \code{\link[lme4]{glmer}}. If a multivariate joint 
-#'   model is specified, then a different family and/or link function can be
-#'   specified for each of the longitudinal submodels. Further, the dependence 
-#'   between the multiple longitudinal submodels is captured through a 
-#'   shared multivariate normal distribution for the group-specific parameters. 
-#'   Multi-level clustered data (e.g. patients within clinics) can be accomodated in the
-#'   longitudinal submodel, provided that the individual (e.g. patient) is the 
-#'   lowest level of clustering. Note that if there are multiple 
-#'   clustering levels (e.g. patients within clinics) then the group-specific 
-#'   parameters within a clustering level are assumed to be correlated since 
-#'   they are drawn from a shared multivariate normal distribution, however, 
-#'   the group-specific parameters at different clustering levels are assumed 
-#'   to be independent. \cr
-#'   \cr
-#'   For the event submodel a parametric proportional hazards model is assumed.
-#'   For the baseline hazard, the user can choose between a Weibull distribution, 
-#'   a piecewise constant baseline hazard (sometimes referred to as piecewise 
-#'   exponential), or an approximation using B-splines. In the case of the 
-#'   piecewise constant or B-splines baseline hazard, the user can optionally 
-#'   control the flexibility by specifying the degrees of freedom or the knot 
-#'   locations. If degrees of freedom are specified (through the \code{df} argument) 
-#'   then the knot locations are automatically generated based on percentiles of
-#'   the distribution of the observed event times (i.e. not including censoring 
-#'   times). Otherwise internal knot locations can be specified 
+#'   For the event submodel a parametric
+#'   proportional hazards model is assumed. The baseline hazard can be estimated 
+#'   using either a Weibull distribution (\code{base_haz = "weibull"}) or a
+#'   piecewise constant baseline hazard (\code{base_haz = "piecewise"}), or 
+#'   approximated using cubic B-splines (\code{base_haz = "bs"}). 
+#'   If either of the latter two are used then the degrees of freedom, 
+#'   or the internal knot locations, can be optionally specified. If
+#'   the degrees of freedom are specified (through the \code{df} argument) then
+#'   the knot locations are automatically generated based on the 
+#'   distribution of the observed event times (not including censoring times). 
+#'   Otherwise internal knot locations can be specified 
 #'   directly through the \code{knots} argument. If neither \code{df} or
 #'   \code{knots} is specified, then the default is to set \code{df} equal to 6.
 #'   It is not possible to specify both \code{df} and \code{knots}. \cr
@@ -193,22 +191,33 @@
 #'   following parameterisations: current value of the linear predictor in the 
 #'   longitudinal submodel (\code{"etavalue"}); first derivative 
 #'   (slope) of the linear predictor in the longitudinal submodel 
-#'   (\code{"etaslope"}); current expected value of the longitudinal submodel 
-#'   (\code{"muvalue"}); shared subject-specific coefficients 
-#'   (\code{"shared_b"}); shared subject-specific coefficients which also
-#'   incorporate the corresponding fixed effect component (\code{"shared_coef"}); 
-#'   or no association structure (equivalent to fitting separate longitudinal 
-#'   and event models) (\code{"null"} or \code{NULL}). More than one association 
-#'   structure can be specified, however, not all combinations are allowed. 
-#'   Moreover, if you are fitting a multivariate joint model then you can 
-#'   optionally choose to use a different association structure(s) for linking 
-#'   each longitudinal submodel to the event submodel by specifying the desired
-#'   association structures in a list.  
+#'   (\code{"etaslope"}); lagged value of the linear predictor in the 
+#'   longitudinal submodel (\code{"etalag(#)"}, replacing \code{#} with the
+#'   desired lag in units of the time variable); the area under the curve of 
+#'   the linear predictor in the longitudinal submodel (\code{"etaauc"}); 
+#'   current expected value of the 
+#'   longitudinal submodel (\code{"muvalue"}); lagged expected value of the
+#'   longitudinal submodel (\code{"mulag(#)"}, replacing \code{#} with the
+#'   desired lag in units of the time variable); the area under the curve of 
+#'   the expected value from the longitudinal submodel (\code{"muauc"}); 
+#'   shared individual-level random  
+#'   effects (\code{"shared_b"}); shared individual-level random effects which also
+#'   incorporate the corresponding fixed effect as well as any corresponding 
+#'   random effects for clustering levels higher than the individual)
+#'   (\code{"shared_coef"}); or no 
+#'   association structure (equivalent to fitting separate longitudinal 
+#'   and event models) (\code{"null"} or \code{NULL}). 
+#'   More than one association structure can be specified, however,
+#'   not all possible combinations are allowed.   
+#'   Note that for the lagged association structures (\code{"etalag(#)"} and 
+#'   \code{"mulag(#)"}) use baseline values (time = 0) for the instances where the 
+#'   time lag results in a time prior to baseline. When using the 
+#'   \code{"etaauc"} or \code{"muauc"} association structures, the area under
+#'   the curve is evaluated using Gauss-Kronrod quadrature with 15 quadrature nodes. 
 #'   By default, \code{"shared_b"} and \code{"shared_coef"} contribute all 
-#'   subject-specific parameters to the association structure; however, a subset 
-#'   of the subject-specific parameters can be chosen by specifying their 
-#'   indices between parentheses as a suffix, for example, "shared_b(1)" or 
-#'   "shared_b(1:3)" or "shared_b(1,2,4)", and so on. \cr
+#'   random effects to the association structure; however, a subset of the random effects can 
+#'   be chosen by specifying their indices between parentheses as a suffix, for 
+#'   example, "shared_b(1)" or "shared_b(1:3)" or "shared_b(1,2,4)", and so on. \cr
 #'   \cr
 #'   Time-varying covariates are allowed in both the 
 #'   longitudinal and event submodels. These should be specified in the data 
@@ -230,13 +239,15 @@
 #'   that are available. \cr
 #'   \cr
 #'   Gauss-Kronrod quadrature is used to numerically evaluate the integral  
-#'   over the cumulative hazard in the likelihood function for the joint model.
+#'   over the cumulative hazard in the likelihood function for the event submodel.
 #'   The accuracy of the numerical approximation can be controlled using the
 #'   number of quadrature nodes, specified through the \code{quadnodes} 
 #'   argument. Using a higher number of quadrature nodes will result in a more 
 #'   accurate approximation.
 #'
 #' @return A \link[=stanjm-object]{stanjm} object is returned.
+#'
+#' @template author
 #' 
 #' @template reference-stan-manual
 #' 
@@ -245,6 +256,8 @@
 #'   \code{\link{posterior_traj}}, \code{\link{posterior_survfit}}, 
 #'   \code{\link{posterior_predict}}, \code{\link{posterior_interval}},
 #'   \code{\link{pp_check}}, \code{\link{ps_check}}.
+#'   
+#' @template see-also-stan-url
 #'    
 #' @examples
 #' \donttest{
@@ -308,7 +321,37 @@
 #'         time_var = "year",
 #'         chains = 3, refresh = 25,
 #'         cores = parallel::detectCores())
-#' summary(mv2)            
+#' summary(mv2)  
+#' 
+#' #####
+#' # Here we provide an example of specifying an association structure 
+#' # based on the lagged value of the linear predictor, where the lag
+#' # is 2 time units (i.e. 2 years in this example)
+#' f3 <- stan_jm(formulaLong = logBili ~ year + (1 | id), 
+#'               dataLong = pbcLong_subset,
+#'               formulaEvent = Surv(futimeYears, death) ~ sex + trt, 
+#'               dataEvent = pbcSurv_subset,
+#'               time_var = "year",
+#'               assoc = "etalag(2)")
+#' summary(f3) 
+#' 
+#' #####
+#' # Here we provide an example of specifying an association structure with 
+#' # interaction terms. Here we specify that we want to use an association
+#' # structure based on the current value of the linear predictor from
+#' # the longitudinal submodel ("etavalue"), but we will also specify
+#' # that we want to interact this with the treatment covariate (trt) from
+#' # pbcLong_subset data frame so that we can estimate a different association 
+#' # parameter (i.e. estimated effect of log serum bilirubin on the log hazard 
+#' # of death) for each treatment group
+#' f4 <- stan_jm(formulaLong = logBili ~ year + (1 | id), 
+#'               dataLong = pbcLong_subset,
+#'               formulaEvent = Surv(futimeYears, death) ~ sex + trt, 
+#'               dataEvent = pbcSurv_subset,
+#'               time_var = "year",
+#'               assoc = c("etavalue", "etavalue_interact(~ trt)"))
+#' summary(f4)  
+#'                     
 #' }
 #' 
 #' @export
@@ -318,7 +361,7 @@
 stan_jm <- function(formulaLong, dataLong, 
                     formulaEvent, dataEvent, 
                     time_var, id_var, family = gaussian,
-                    assoc = "etavalue",
+                    assoc = "etavalue", interaction_data,
                     base_haz = c("weibull", "bs", "piecewise"), 
                     df, knots, quadnodes = 15, 
                     subsetLong, subsetEvent, 
@@ -326,17 +369,17 @@ stan_jm <- function(formulaLong, dataLong,
                     weights, offset, contrasts,
                     centreLong = FALSE, centreEvent = FALSE, 
                     init = "model_based", ...,				          
-					          priorLong = normal(), priorLong_intercept = normal(),
+                    priorLong = normal(), priorLong_intercept = normal(),
                     priorLong_ops = priorLong_options(),
                     priorEvent = normal(), priorEvent_intercept = normal(),
-					          priorEvent_ops = priorEvent_options(),
-					          priorAssoc = normal(),
-					          priorAssoc_ops = priorAssoc_options(),
+                    priorEvent_ops = priorEvent_options(),
+                    priorAssoc = normal(),
+                    priorAssoc_ops = priorAssoc_options(),
                     prior_covariance = decov(), prior_PD = FALSE,
-					          adapt_delta = NULL, max_treedepth = NULL, QR = FALSE, 
-					          algorithm = c("sampling", "meanfield", "fullrank")) {
-
-
+                    adapt_delta = NULL, max_treedepth = NULL, QR = FALSE, 
+                    algorithm = c("sampling", "meanfield", "fullrank")) {
+  
+  
   #=============================
   # Pre-processing of arguments
   #=============================  
@@ -355,7 +398,7 @@ stan_jm <- function(formulaLong, dataLong,
   if (missing(weights)) weights <- NULL
   if (missing(id_var)) id_var <- NULL
   if (missing(subsetLong)) subsetLong <- NULL
-  if (missing(subsetEvent)) subsetEvent <- NULL
+  if (missing(interaction_data)) interaction_data <- NULL
   
   # Matched call
   call <- match.call(expand.dots = TRUE)    
@@ -371,12 +414,12 @@ stan_jm <- function(formulaLong, dataLong,
     mc$adapt_delta <- mc$max_treedepth <- 
     mc$... <- mc$QR <- NULL
   mc$weights <- NULL
-
+  
   # Create call for longitudinal submodel  
   y_mc <- mc
   y_mc <- strip_nms(y_mc, "Long") 
   y_mc$formulaEvent <- y_mc$dataEvent <- y_mc$subsetEvent <- NULL
-
+  
   # Is formulaLong a list?
   if (is(eval(y_mc$formula), "formula")) { # number of long. markers
     formula_list <- FALSE
@@ -384,7 +427,8 @@ stan_jm <- function(formulaLong, dataLong,
   } else if (is.list(eval(y_mc$formula))) {
     formula_list <- TRUE
     M <- length(eval(y_mc$formula))
-    if (!all(sapply(eval(y_mc$formula), function(x) (is(x, "formula")))))
+    if (!all(sapply(eval(y_mc$formula), function(x)
+      (is(x, "formula")))))
       stop("'formulaLong' should be a formula object or a list of formula ",
            "objects")               
   } else {
@@ -392,7 +436,7 @@ stan_jm <- function(formulaLong, dataLong,
          "joint model, a list of formula objects with length equal to the ",
          "desired number of longitudinal markers")
   }
-
+  
   # Is dataLong a list?
   if (is.data.frame(eval(y_mc$data))) {
     data_list <- FALSE
@@ -457,7 +501,7 @@ stan_jm <- function(formulaLong, dataLong,
                           "poisson", "neg_binomial_2")
   family <- lapply(family, validate_family)
   fam <- lapply(family, function(x) 
-                which(pmatch(supported_families, x$family, nomatch = 0L) == 1L))
+    which(pmatch(supported_families, x$family, nomatch = 0L) == 1L))
   if (any(lapply(fam, length) == 0L)) 
     stop("'family' must be one of ", paste(supported_families, collapse = ", "))
   supported_links <- lapply(fam, function(x) 
@@ -476,7 +520,7 @@ stan_jm <- function(formulaLong, dataLong,
                  family, seq_along(family), SIMPLIFY = TRUE)
   if (any(lapply(link, length) == 0L)) 
     stop("'link' must be one of ", paste(supported_links, collapse = ", "))
-
+  
   # Check for weights
   has_weights <- (!is.null(weights))
   
@@ -491,17 +535,17 @@ stan_jm <- function(formulaLong, dataLong,
     if (!is.null(family_list))   
       m_mc[[m]]$family  <- if (family_list)   eval(y_mc$family)[[m]]  else y_mc$family    
   }
-   
+  
   # Create call for event submodel
   e_mc <- mc
   e_mc <- strip_nms(e_mc, "Event")
   e_mc$formulaLong <- e_mc$dataLong <- e_mc$family <-
     e_mc$subsetLong <- NULL
-                          
+  
   # Standardised GK quadrature points and weights
   quadpoints <- get_quadpoints(quadnodes)
-            
-     
+  
+  
   #================================
   # Data for longitudinal submodel
   #================================
@@ -543,9 +587,9 @@ stan_jm <- function(formulaLong, dataLong,
   b_Cov           <- list()   # initial values for correlation matrix
   b_Corr          <- list()   # initial values for correlation matrix
   ord             <- list()   # ordering of y vector, only present if outcome is bernoulli
-
-  for (m in 1:M) {
   
+  for (m in 1:M) {
+    
     # Fit separate longitudinal model
     if ((family[[m]]$family == "gaussian") && (family[[m]]$link == "identity")) {
       m_mc[[m]][[1]] <- quote(lme4::lmer)
@@ -560,7 +604,7 @@ stan_jm <- function(formulaLong, dataLong,
       m_mc[[m]]$control <- get_control_args(glmer = TRUE)               
     }
     y_mod[[m]] <- eval(m_mc[[m]], parent.frame())      
-
+    
     # Error check: time_var is one of the longitudinal covariates
     # NB REMOVED, since difficult to check for time_var if it is 
     #   transformed (for example used in spline terms)
@@ -590,7 +634,7 @@ stan_jm <- function(formulaLong, dataLong,
       y_has_intercept_upbound[m] <- 0L
     } 
     xtemp[[m]] <- if (y_has_intercept[m]) x[[m]][, -1L, drop=FALSE] else x[[m]]
-
+    
     if (is.binomial(family[[m]]$family)) {
       if (NCOL(y[[m]]) == 1L) {
         if (is.numeric(y[[m]]) || is.logical(y[[m]])) 
@@ -607,20 +651,20 @@ stan_jm <- function(formulaLong, dataLong,
         y[[m]] <- as.integer(y[[m]][, 1L])
       }
     } else trials[[m]] <- rep(0L, length(y[[m]]))
-
+    
     # Random effect terms
     Ztlist[[m]] <- lme4::getME(y_mod[[m]], "Ztlist")
     y_cnms[[m]]  <- lme4::getME(y_mod[[m]], "cnms")
     y_flist[[m]] <- lme4::getME(y_mod[[m]], "flist")
     y_offset[[m]] <- lme4::getME(y_mod[[m]], "offset")
-        
+    
     # Centred design matrix, if required
     if (centreLong) {
       y_centre[m] <- 1L
       xbar[[m]] <- colMeans(xtemp[[m]])
       xtemp[[m]] <- sweep(xtemp[[m]], 2, xbar[[m]], FUN = "-")
     }
-
+    
     # Reorder y, X, Z if bernoulli (zeros first)
     if (is.binomial(family[[m]]$family) && all(y[[m]] %in% 0:1)) {      
       ord[[m]] <- order(y[[m]])
@@ -636,11 +680,11 @@ stan_jm <- function(formulaLong, dataLong,
     y_real_N[m] <- if (y_is_real[m]) y_N[m] else 0L
     y_int_N[m] <- if (!y_is_real[m]) y_N[m] else 0L
     y_K[m] <- NCOL(xtemp[[m]])
-
+    
     # Update formula if using splines or other data dependent predictors
     y_vars[[m]] <- get_formvars(y_mod[[m]])
-
-    # Model based initial values
+    
+    # Model based initial values or informative priors
     if (y_has_intercept_unbound[m]) {
       y_beta[[m]] <- lme4::fixef(y_mod[[m]])[-1L]
       se_y_beta[[m]] <- summary(y_mod[[m]])$coefficients[, "Std. Error"][-1L]
@@ -680,7 +724,7 @@ stan_jm <- function(formulaLong, dataLong,
       disp_mark <- sum(y_has_dispersion[1:m])
       y_dispersion[disp_mark] <- sigma(y_mod[[m]])
     }
-
+    
   }
   
   # Sum dimensions across all longitudinal submodels
@@ -705,8 +749,8 @@ stan_jm <- function(formulaLong, dataLong,
   # Additional error checks
   id_var <- check_id_var(id_var, y_cnms)
   id_list <- check_id_list(id_var, y_flist)
-
-  # Construct prior weights
+  
+  # Construct weights
   if (has_weights) {
     if ((!is.data.frame(weights)) || (!ncol(weights) == 2))
       stop("'weights' argument should be a data frame with two columns: the first ",
@@ -722,7 +766,7 @@ stan_jm <- function(formulaLong, dataLong,
       stop("The weights supplied must be numeric.", call. = FALSE)
     if (any(wts < 0)) 
       stop("Negative weights are not allowed.", call. = FALSE)
-
+    
     # Check only one weight per ID
     n_weights_per_id <- tapply(weights[[weight_var]], weights[[id_var]], length)
     if (!all(n_weights_per_id == 1L))
@@ -748,7 +792,7 @@ stan_jm <- function(formulaLong, dataLong,
         y_weights[[m]] <- y_weights[[m]][ord[[m]]]
     }
   } else y_weights <- lapply(1:M, function(m) rep(0.0, length(y[[m]])))
-    
+  
   # Construct single cnms list for all longitudinal submodels
   y_cnms_nms <- lapply(y_cnms, names)
   cnms_nms <- unique(unlist(y_cnms_nms))
@@ -763,13 +807,13 @@ stan_jm <- function(formulaLong, dataLong,
   famname <- lapply(fam, function(x) supported_families[x])
   is_bernoulli  <- mapply(function(x, i)
     is.binomial(x) && all(y[[i]] %in% 0:1),
-                          famname, seq_along(famname), SIMPLIFY = FALSE)
+    famname, seq_along(famname), SIMPLIFY = FALSE)
   is_nb         <- lapply(famname, is.nb)
   is_gaussian   <- lapply(famname, is.gaussian)
   is_gamma      <- lapply(famname, is.gamma)
   is_ig         <- lapply(famname, is.ig)
   is_continuous <- lapply(seq_along(famname), function(x) 
-                     (is_gaussian[[x]] || is_gamma[[x]] || is_ig[[x]]))
+    (is_gaussian[[x]] || is_gamma[[x]] || is_ig[[x]]))
   
   # Require intercept for certain family and link combinations
   lapply(1:M, function(x) {
@@ -785,12 +829,13 @@ stan_jm <- function(formulaLong, dataLong,
                     ", the model must have an intercept."))
     }
   })
-    
+  
+  is_lmer <- lapply(family, is.lmer)
   
   #=========================
   # Data for event submodel
   #=========================
-
+  
   # Items to store for event submodel
   e_beta <- c()
   
@@ -799,7 +844,7 @@ stan_jm <- function(formulaLong, dataLong,
   base_haz_weibull <- (base_haz == "weibull")
   base_haz_piecewise <- (base_haz == "piecewise")
   base_haz_bs <- (base_haz == "bs")
-
+  
   if (!(base_haz_bs || base_haz_piecewise)) { # not bs or piecewise
     if (!missing(df)) {
       warning("'df' will be ignored since 'base_haz' was not set ",
@@ -849,76 +894,79 @@ stan_jm <- function(formulaLong, dataLong,
   e_mc$x <- TRUE
   e_mod <- eval(e_mc, parent.frame())
   e_fr <- e_mf <- expand.model.frame(e_mod, id_var, na.expand = TRUE)
-  e_mf <- cbind(unclass(e_mf[,1]), e_mf[,-1])
-
+  e_mf <- cbind(unclass(e_mf[,1]), e_mf[, -1, drop = FALSE])
+  
   # Check ID sorting
   e_id_list <- factor(unique(e_mf[, id_var]))
   if (!identical(id_list, e_id_list))
     stop("'dataEvent' needs to be sorted by the subject ",
          "ID/grouping variable", call. = FALSE)
-
+  
   e_y <- e_mod$y
   
-  # For each individual, identify final event time and event indicator
+  # Entry and exit times
+  entrytime <- rep(0, length(id_list)) # entry times current assumed to be zero for all individuals
   if (attr(e_y, "type") == "counting") {
     tvc         <- TRUE
-    mf_event    <- do.call(rbind, lapply(
-                             split(e_mf, e_mf[, id_var]),
-                             function(d) d[which.max(d[,"stop"]), ]))
-    flist_event <- mf_event[, id_var]
-    eventtime   <- mf_event$stop
-    d           <- mf_event$status
-    names(eventtime) <- names(d) <- flist_event
+    mf_event    <- do.call(rbind, lapply(split(e_mf, e_mf[, id_var]), function(d) d[which.max(d[,"stop"]), ]))
+    eventtime   <- mf_event[["stop"]]
+  } else if (attr(e_y, "type") == "right") {
+    tvc         <- FALSE 
+    mf_event    <- e_mf
+    eventtime   <- mf_event[["time"]]
+  } else stop("Only 'right' or 'counting' type Surv objects are allowed 
+               on the LHS of the event submodel formula")
+  
+  # Event indicator and ID list
+  d           <- mf_event[["status"]]  
+  flist_event <- mf_event[[id_var]]
+  names(eventtime) <- names(d) <- flist_event
+  
+  # Unstandardised quadrature points
+  quadpoint <- lapply(quadpoints$points, unstandardise_quadpoints, entrytime, eventtime)
+  t_q <- c(list(eventtime), quadpoint)
+  names(quadpoint) <- paste0("quadpoint", seq(quadnodes))
+  names(t_q) <- c("eventtime", names(quadpoint))
+  
+  # Obtain design matrix at event times and unstandardised quadrature points
+  
+  if (tvc) {  # time varying covariates in event model
     
+    # Model frame at event times
     e_mf           <- data.table(e_mf, key = c(id_var, "start"))
     e_mf[["start"]] <- as.numeric(e_mf[["start"]])
     e_mf_eventtime <- e_mf[, .SD[.N], by = get(id_var)]
-    e_mf_eventtime <- e_mf_eventtime[, get := NULL]
-    # Unstandardised quadrature points
-    quadpoint <- lapply(quadpoints$points, FUN = function(x) 
-                          (eventtime/2) * x + (eventtime/2))
+    e_mf_eventtime <- e_mf_eventtime[, get := NULL]   
+    
     # Model frame corresponding to observation times which are 
     #   as close as possible to the unstandardised quadrature points                      
-    e_mf_quadtime  <- do.call(rbind, lapply(quadpoint, FUN = function(x) 
-                         e_mf[data.table::SJ(flist_event, x), 
-                         roll = TRUE, rollends = c(TRUE, TRUE)]))
+    e_mf_q  <- do.call(rbind, lapply(quadpoint, FUN = function(x)
+      e_mf[data.table::SJ(flist_event, x), roll = TRUE, rollends = c(TRUE, TRUE)]))
+    
     # Model frame evaluated at both event times and quadrature points
-    e_mf_quadtime <- rbind(e_mf_eventtime, e_mf_quadtime, idcol = "xbind.id")
+    e_mf_q <- rbind(e_mf_eventtime, e_mf_q)
+    
     # Design matrix evaluated at event times and quadrature points
     #   NB Here there are time varying covariates in the event submodel and
     #   therefore the design matrix differs depending on the quadrature point 
     fm_RHS <- delete.response(terms(e_mod))
-    e_x_quadtime   <- model.matrix(fm_RHS, data = e_mf_quadtime)
-  } else if (attr(e_y, "type") == "right") {
-    tvc         <- FALSE 
-    mf_event    <- e_mf
-    flist_event <- mf_event[, id_var]
-    eventtime   <- mf_event$time
-    d           <- mf_event$status
-    names(eventtime) <- names(d) <- flist_event
-    # Unstandardised quadrature points
-    quadpoint <- lapply(quadpoints$points, FUN = function(x) {
-      tmp <- (eventtime/2) * x + (eventtime/2)
-      names(tmp) <- flist_event
-      tmp
-    })
-    names(quadpoint) <- paste0("quadpoint", seq(quadnodes))
+    e_x_quadtime   <- model.matrix(fm_RHS, data = e_mf_q)
+    
+  } else {  # no time varying covariates in event model
+    
     # Design matrix evaluated at event times and quadrature points
     #   NB Here there are no time varying covariates in the event submodel and
     #   therefore the design matrix is identical at event time and at all
     #   quadrature points
-    e_x_quadtime   <- do.call(rbind, lapply(1:(quadnodes + 1), 
-                                            FUN = function(x) e_mod$x))
-  } else stop("Only 'right' or 'counting' type Surv objects are allowed 
-               on the LHS of the event submodel formula")
-
-  # Evaluate spline basis (knots, df, etc) based on distribution
-  # of observed event times
+    e_x_quadtime   <- do.call(rbind, lapply(1:(quadnodes + 1), FUN = function(x) e_mod$x))
+    
+  }
+  
+  # Evaluate spline basis (knots, df, etc) based on distributionof observed event times
   if (base_haz_bs) 
     bs_basis <- splines::bs(eventtime[(d > 0)], df = df, knots = knots, 
-                                 Boundary.knots = c(0, max(eventtime)), 
-                                 intercept = TRUE)
-
+                            Boundary.knots = c(0, max(eventtime)), intercept = TRUE)
+  
   # Evaluate cut points for piecewise constant
   if (base_haz_piecewise) {
     if (is.null(knots)) {
@@ -936,28 +984,28 @@ stan_jm <- function(formulaLong, dataLong,
       knots <- c(0, knots, max(eventtime))
     }
   }
-                 
+  
   # Incorporate intercept term (since Cox model does not have intercept)
   # -- depends on baseline hazard
   if (base_haz_weibull & (!"(Intercept)" %in% colnames(e_x_quadtime)))
     e_x_quadtime  <- cbind("(Intercept)" = rep(1, NROW(e_x_quadtime)), e_x_quadtime)
-
+  
   # Centering of design matrix for event model
-  e_x <- as.matrix(e_x_quadtime)  
-  e_has_intercept <- grepl("(Intercept", colnames(e_x)[1L], fixed = TRUE)
+  e_x <- as.matrix(e_x_quadtime) 
+  e_has_intercept <- if (length(colnames(e_x))) 
+    grepl("(Intercept", colnames(e_x)[1L], fixed = TRUE) else FALSE
   e_xtemp <- if (e_has_intercept) e_x[, -1L, drop=FALSE] else e_x
   if (centreEvent) {
     e_xbar <- colMeans(e_xtemp)
     e_xtemp <- sweep(e_xtemp, 2, e_xbar, FUN = "-")
   }
   
+    
   # Some additional bits -- NB weights here are quadrature weights, not prior weights
   e_K <- NCOL(e_xtemp)
   Npat <- length(eventtime)
-  weights_rep <- rep(quadpoints$weights, each = Npat)  
-  eventtime_rep <- rep(eventtime, times = quadnodes)  
-  weights_times_half_eventtime <- 0.5 * weights_rep * eventtime_rep   
-
+  quadweight <- unlist(lapply(quadpoints$weights, unstandardise_quadweights, entrytime, eventtime))
+  
   # Construct prior weights for event submodel
   if (has_weights) {
     flist_df <- data.frame(id = flist_event)
@@ -969,11 +1017,7 @@ stan_jm <- function(formulaLong, dataLong,
     e_weights <- rep(0.0, Npat)
     e_weights_rep <- rep(0.0, Npat * quadnodes)
   }
- 
-  # Model based initial values
-  e_beta <- e_mod$coef
-  se_e_beta <- sqrt(diag(e_mod$var))
-    
+  
   # Error checks for the ID variable
   if (!identical(id_list, factor(sort(unique(flist_event)))))
     stop("The patient IDs (levels of the grouping factor) included ",
@@ -982,8 +1026,11 @@ stan_jm <- function(formulaLong, dataLong,
     stop("The number of patients differs between the longitudinal and ",
          "event submodels. Perhaps you intended to use 'start/stop' notation ",
          "for the Surv() object.")
-    
-
+  
+  # Model based initial values
+  e_beta <- e_mod$coef
+  se_e_beta <- sqrt(diag(e_mod$var))
+  
   #================================
   # Data for association structure
   #================================
@@ -993,119 +1040,135 @@ stan_jm <- function(formulaLong, dataLong,
   eps <- 1E-5
   
   # Check association structure
-  supported_assocs <- c("null", "etavalue", "muvalue", "etaslope", 
-                        "muslope", "shared_b", "shared_coef")
+  supported_assocs <- c("null", 
+                        "etavalue", "muvalue", 
+                        "etaslope", "muslope", 
+                        "etalag",   "mulag",
+                        "etaauc",   "muauc",
+                        "shared_b", "shared_coef",
+                        "etavalue_interact", "muvalue_interact",
+                        "etaslope_interact", "muslope_interact")
   assoc <- lapply(1:M, validate_assoc, 
                   assoc, y_cnms, supported_assocs, id_var, x)
   assoc <- list_nms(assoc, M)
-
+  
   # Indicator of each association type, for each longitudinal submodel
   has_assoc <- sapply(supported_assocs, function(x) 
     sapply(assoc, function(y) as.integer(y[[x]])), simplify = FALSE)
   
-  which_b_zindex <- lapply(1:M, function(m) assoc[[m]]$which_b_zindex)
-  which_coef_zindex <- lapply(1:M, function(m) assoc[[m]]$which_coef_zindex)
-  which_coef_xindex <- lapply(1:M, function(m) assoc[[m]]$which_coef_xindex)
+  which_b_zindex <- lapply(assoc, `[[`, "which_b_zindex")
+  which_coef_zindex <- lapply(assoc, `[[`, "which_coef_zindex")
+  which_coef_xindex <- lapply(assoc, `[[`, "which_coef_xindex")
   size_which_b <- sapply(which_b_zindex, length)
   size_which_coef <- sapply(which_coef_zindex, length)
-  a_K <- get_num_assoc_pars(has_assoc, which_b_zindex, which_coef_zindex)
-
-
-  #====================================================================
-  # Longitudinal submodel: calculate design matrices, and id vector 
+  a_K <- get_num_assoc_pars(has_assoc, which_b_zindex, which_coef_zindex)  # doesn't include parameters for interaction terms (added on later)
+  
+  # Unstandardised quadrature nodes for AUC association structure
+  auc_quadnodes <- 15
+  auc_quadpoints <- get_quadpoints(auc_quadnodes)
+  auc_quadweight <- unlist(
+    lapply(t_q, function(x) 
+      lapply(x, function(y) 
+        lapply(auc_quadpoints$weights, unstandardise_quadweights, 0, y))))
+  
+  #==================================================
+  # Longitudinal submodel: calculate design matrices 
   # at the event times and quadrature points
-  #====================================================================
-    
+  #==================================================
+  
   # Items to store for each longitudinal submodel
-  y_mod_q         <- list()   # fitted long. submodels at quadpoints
+  y_mod_q         <- list()   # fitted long. submodels at event times and quadrature points
   y_fr            <- list()   # model frame with the addition of time_var
-  xq              <- list()   # design matrix before removing intercept 
-                              # and centering
-  xqtemp          <- list()   # design matrix (without intercept) for 
-                              # longitudinal submodel calculated at event 
-                              # and quad times, possibly centred
+  xq              <- list()   # design matrix before removing intercept and centering
+  xqtemp          <- list()   # design matrix after removing intercept and possibly centred
   Ztlistq         <- list()   # random effects matrix at event and quad times
-  y_cnmsq         <- list()
+  y_cnmsq         <- list() 
   y_flistq        <- list()
+  
   y_mod_q_eps     <- list()   # fitted long. submodels under time shift of epsilon
-  xq_eps          <- list()   # xq with time shift of epsilon
-  xqtemp_eps      <- list()   # xqtemp with time shift of epsilon  
-  Ztlistq_eps     <- list()   # random effects matrix with time shift of epsilon
+  xq_eps          <- list()   
+  xqtemp_eps      <- list()  
+  Ztlistq_eps     <- list()
   y_cnmsq_eps     <- list()
   y_flistq_eps    <- list()
+  
+  y_mod_q_lag     <- list()   # fitted long. submodels under time lag
+  xq_lag          <- list()  
+  xqtemp_lag      <- list()  
+  Ztlistq_lag     <- list()  
+  y_cnmsq_lag     <- list()
+  y_flistq_lag    <- list()
+  
+  y_mod_q_auc     <- list()   # fitted long. submodels at subquadrature points
+  xq_auc          <- list()  
+  xqtemp_auc      <- list()  
+  Ztlistq_auc     <- list()  
+  y_cnmsq_auc     <- list()
+  y_flistq_auc    <- list()  
+  
+  xq_int          <- list()   # design matrix for covariates to interact with etavalue, etaslope, etc
+  xqtemp_int      <- list()
+  a_K_int         <- list()
   
   # Set up a second longitudinal model frame which includes the time variable
   for (m in 1:M) {
     m_mc_temp         <- m_mc[[m]]
     m_mc_temp[[1]]    <- quote(lme4::glFormula)    
-    m_mc_temp$formula <- do.call(update.formula, list(
-                                    m_mc[[m]]$formula, 
-                                    paste0("~ . +", time_var))) 
-    if ((family[[m]]$family == "gaussian") && (family[[m]]$link == "identity")) {
-      m_mc_temp$control <- get_control_args(norank = TRUE)
-    } else {
-      m_mc_temp$control <- get_control_args(glmer = TRUE, norank = TRUE)
-    }     
+    m_mc_temp$formula <- do.call(update.formula, list(m_mc[[m]]$formula, paste0("~ . +", time_var))) 
+    m_mc_temp$control <- get_control_args(glmer = !is_lmer[[m]], norank = TRUE)
     
     # Obtain model frame with time_var definitely included
     y_mod_wtime <- eval(m_mc_temp, parent.frame())      
     y_fr[[m]] <- y_mod_wtime$fr
     
-    # Update model based on predvars and obtain new model frame
+    # Convert model frame to data.table
     mf <- data.table::data.table(y_mod_wtime$fr, key = c(id_var, time_var))
-    mf[[time_var]] <- as.numeric(mf[[time_var]])  # ensures no integer rounding during data.table merge
-  
-    # Identify which row in longitudinal data is closest to event time
-    mf_eventtime <- mf[data.table::SJ(flist_event, eventtime), 
-                          roll = TRUE, rollends = c(FALSE, TRUE)]
-  
-    # Identify which row in longitudinal data is closest to quadrature point
-    #   NB if the quadrature point is earlier than the first observation time, 
-    #   then covariates values are carried back to avoid missing values. 
-    #   In any other case, the observed covariate values from the most recent 
-    #   observation time preceeding the quadrature point are carried forward to  
-    #   represent the covariate value(s) at the quadrature point. (To avoid   
-    #   missingness there is no limit on how far forwards or how far backwards
-    #   covariate values can be carried). If no time varying covariates are present
-    #   in the longitudinal submodel (other than the time variable) then nothing 
-    #   is carried forward or backward.
-    mf_quadtime <- do.call(rbind, lapply(quadpoint, FUN = function(x) 
-                           mf[data.table::SJ(flist_event, x), 
-                           roll = TRUE, rollends = c(TRUE, TRUE)]))
+    mf[[time_var]] <- as.numeric(mf[[time_var]])
     
-    # Obtain long design matrix evaluated at event times (xbind.id == 1) and  
-    #   quadrature points (xbind.id == 2)
-    names(mf_eventtime)[names(mf_eventtime) == "eventtime"] <- time_var
-    names(mf_quadtime)[names(mf_quadtime) == "quadpoint"]   <- time_var
-    mf_quadtime <- rbind(mf_eventtime, mf_quadtime, idcol = "xbind.id")
+    # Identify row in longitudinal data closest to event time or quadrature point
+    #   NB if the quadrature point is earlier than the first observation time, 
+    #   then covariates values are carried back to avoid missing values.
+    #   In any other case, the 
+    #   observed covariates values from the most recent observation time
+    #   preceeding the quadrature point are carried forward to represent the 
+    #   covariate value(s) at the quadrature point. (To avoid missingness  
+    #   there is no limit on how far forwards or how far backwards covariate 
+    #   values can be carried). If no time varying covariates are present in
+    #   the longitudinal submodel (other than the time variable) then nothing 
+    #   is carried forward or backward.
+    mf_q <- do.call(rbind, lapply(t_q, FUN = function(x) 
+      mf[data.table::SJ(flist_event, x), roll = TRUE, rollends = c(TRUE, TRUE)]))
+    
+    # Obtain long design matrix evaluated at event times and quadrature points
+    names(mf_q)[names(mf_q) == "t_q"] <- time_var
     m_mc_temp$formula <- m_mc[[m]]$formula  # return to original formula
     m_mc_temp$formula <- use_these_vars(y_mod[[m]], 
                                         c(y_vars[[m]]$formvars$fixed[-1], y_vars[[m]]$formvars$random[-1]), 
                                         c(y_vars[[m]]$predvars$fixed[-1], y_vars[[m]]$predvars$random[-1]))
     m_mc_temp$control <- m_mc[[m]]$control  # return to original control args
-    m_mc_temp$data    <- mf_quadtime        # data at event and quadrature times
+    m_mc_temp$data    <- mf_q               # data at event and quadrature times
     y_mod_q[[m]] <- eval(m_mc_temp, parent.frame())     
-         
+    
     xq[[m]] <- as.matrix(y_mod_q[[m]]$X)
     xqtemp[[m]] <- if (y_has_intercept[m]) xq[[m]][, -1L, drop=FALSE] else xq[[m]]  
     Ztlistq[[m]] <- y_mod_q[[m]]$reTrms$Ztlist
     y_cnmsq[[m]] <- y_mod_q[[m]]$reTrms$cnms
     y_flistq[[m]] <- y_mod_q[[m]]$reTrms$flist
     
-      #Needs working out to appropriately deal with offsets??
-      #offset_quadtime <- model.offset(mod_quadtime$fr) %ORifNULL% double(0)
-
+    #Needs working out to appropriately deal with offsets??
+    #offset_quadtime <- model.offset(mod_quadtime$fr) %ORifNULL% double(0)
+    
     # Centering of design matrix for longitudinal model at event times
     # and quadrature times 
     if (centreLong) xqtemp[[m]] <- sweep(xqtemp[[m]], 2, xbar[[m]], FUN = "-")
     
     # If association structure is based on slope, then calculate design 
     # matrices under a time shift of epsilon
-    if (sum(has_assoc$etaslope, has_assoc$muslope)) {
-      mf_quadtime_eps <- mf_quadtime
-      mf_quadtime_eps[[time_var]] <- mf_quadtime_eps[[time_var]] + eps
+    if (sum(has_assoc$etaslope, has_assoc$muslope, has_assoc$etaslope_interact, has_assoc$muslope_interact)) {
+      mf_q_eps <- mf_q
+      mf_q_eps[[time_var]] <- mf_q_eps[[time_var]] + eps
       m_mc_temp_eps <- m_mc_temp
-      m_mc_temp_eps$data    <- mf_quadtime_eps
+      m_mc_temp_eps$data <- mf_q_eps
       y_mod_q_eps[[m]] <- eval(m_mc_temp_eps, parent.frame())
       xq_eps[[m]] <- as.matrix(y_mod_q_eps[[m]]$X)
       xqtemp_eps[[m]] <- if (y_has_intercept[m]) xq_eps[[m]][, -1L, drop=FALSE] else xq_eps[[m]]  
@@ -1113,19 +1176,101 @@ stan_jm <- function(formulaLong, dataLong,
       Ztlistq_eps[[m]] <- y_mod_q_eps[[m]]$reTrms$Ztlist
       y_cnmsq_eps[[m]] <- y_mod_q_eps[[m]]$reTrms$cnms
       y_flistq_eps[[m]] <- y_mod_q_eps[[m]]$reTrms$flist
-    }    
+    } 
+    
+    # If association structure is based on a time lag, then calculate design 
+    # matrices under the specified time lag
+    if (sum(has_assoc$etalag, has_assoc$mulag)) {
+      t_q_lag <- lapply(t_q, function(x) {
+        tmp <- x - assoc[[m]]$which_lag
+        tmp[tmp < 0] <- 0.0  # use baseline where lagged t is before baseline
+        tmp
+      })
+      mf_q_lag <- do.call(rbind, lapply(t_q_lag, FUN = function(x) 
+        mf[data.table::SJ(flist_event, x), roll = TRUE, rollends = c(TRUE, TRUE)]))
+      m_mc_temp_lag <- m_mc_temp
+      m_mc_temp_lag$data <- mf_q_lag
+      y_mod_q_lag[[m]] <- eval(m_mc_temp_lag, parent.frame())
+      xq_lag[[m]] <- as.matrix(y_mod_q_lag[[m]]$X)
+      xqtemp_lag[[m]] <- if (y_has_intercept[m]) xq_lag[[m]][, -1L, drop=FALSE] else xq_lag[[m]]  
+      if (centreLong) xqtemp_lag[[m]] <- sweep(xqtemp_lag[[m]], 2, xbar[[m]], FUN = "-")
+      Ztlistq_lag[[m]] <- y_mod_q_lag[[m]]$reTrms$Ztlist
+      y_cnmsq_lag[[m]] <- y_mod_q_lag[[m]]$reTrms$cnms
+      y_flistq_lag[[m]] <- y_mod_q_lag[[m]]$reTrms$flist
+    } 
+    
+    # If association structure is based on area under the marker trajectory, then 
+    # calculate design matrices at the subquadrature points
+    if (sum(has_assoc$etaauc, has_assoc$muauc)) {
+      # Return a design matrix that is (quadnodes * auc_quadnodes * Npat) rows
+      t_q_auc <- lapply(t_q, function(x) 
+        unlist(lapply(x, function(y) lapply(auc_quadpoints$points, unstandardise_quadpoints, 0, y))))
+      mf_q_auc <- do.call(rbind, lapply(t_q_auc, function(x)
+          mf[data.table::SJ(rep(flist_event, each = auc_quadnodes), x), roll = TRUE, rollends = c(TRUE, TRUE)]))
+      m_mc_temp_auc <- m_mc_temp
+      m_mc_temp_auc$data <- mf_q_auc
+      y_mod_q_auc[[m]] <- eval(m_mc_temp_auc, parent.frame())
+      xq_auc[[m]] <- as.matrix(y_mod_q_auc[[m]]$X)
+      xqtemp_auc[[m]] <- if (y_has_intercept[m]) xq_auc[[m]][, -1L, drop=FALSE] else xq_auc[[m]]  
+      if (centreLong) xqtemp_auc[[m]] <- sweep(xqtemp_auc[[m]], 2, xbar[[m]], FUN = "-")
+      Ztlistq_auc[[m]] <- y_mod_q_auc[[m]]$reTrms$Ztlist
+      y_cnmsq_auc[[m]] <- y_mod_q_auc[[m]]$reTrms$cnms
+      y_flistq_auc[[m]] <- y_mod_q_auc[[m]]$reTrms$flist
+    }      
+    
+    # If association structure is based on interactions with data, then calculate 
+    # the design matrix which will be multiplied by etavalue, etaslope, muvalue or muslope
+    xq_int[[m]] <- sapply(
+      c("etavalue_interact", "etaslope_interact", 
+        "muvalue_interact", "muslope_interact"),
+      function(x) {
+        if (has_assoc[[x]][[m]]) {
+          fm <- assoc[[m]]$formula_interact[[x]]
+          vars <- rownames(attr(terms.formula(fm), "factors"))
+          if (is.null(vars))
+            stop(paste0("No variables found in the formula specified for the '", x,
+                        "' association structure.", call. = FALSE))
+          ff <- ~ foo + bar
+          gg <- parse(text = paste("~", paste(c(id_var, time_var), collapse = "+")))[[1L]]
+          ff[[2L]][[2L]] <- fm[[2L]]
+          ff[[2L]][[3L]] <- gg[[2L]]
+          oldcall <- getCall(y_mod[[m]])
+          naa <- if (is.null(interaction_data)) oldcall$na.action
+          subset <- if (is.null(interaction_data)) oldcall$subset else NULL               
+          df <- if (is.null(interaction_data)) eval(m_mc[[m]]$data) else interaction_data
+          sel <- which(!vars %in% colnames(df))
+          if (length(sel))
+            stop(paste0("The following variables were specified in the formula for the '", x,
+                        "' association structure, but they cannot be found in the data: ", 
+                        paste0(vars, collapse = ", ")))
+          mf <- eval(call("model.frame", ff, data = df, subset = subset, 
+                          na.action = naa), envir = environment(formula(y_mod[[m]])))
+          mf <- data.table::data.table(mf, key = c(id_var, time_var))
+          mf[[time_var]] <- as.numeric(mf[[time_var]])
+          mf_q_int <- do.call(rbind, lapply(t_q, FUN = function(x) 
+            mf[data.table::SJ(flist_event, x), roll = TRUE, rollends = c(TRUE, TRUE)]))
+          xq_int <- stats::model.matrix(fm, data = mf_q_int)
+          if ("(Intercept)" %in% colnames(xq_int)) 
+            xq_int <- xq_int[, -1L, drop = FALSE]
+          if (!ncol(xq_int))
+            stop(paste0("Bug found: A formula was specified for the '", x, "' association ", 
+                        "structure, but the resulting design matrix has no columns."), call. = FALSE)
+        } else xq_int <- matrix(0, length(unlist(t_q)), 0)
+        xq_int
+      }, simplify = FALSE, USE.NAMES = TRUE)
+    a_K_int[[m]] <- sapply(xq_int[[m]], ncol)
+    xqtemp_int[[m]] <- do.call(cbind, xq_int[[m]])
+    
   }
+  a_K <- a_K + sum(unlist(a_K_int))
   
-
   #=====================
   # Prior distributions
   #=====================
- 
-  ok_dists <- nlist("normal", student_t = "t", "cauchy", "hs", "hs_plus",
-                               "informative_normal", informative_student_t = "informative_t",
-                               "informative_cauchy")
-  ok_intercept_dists <- if (length(ok_dists) > 5L) ok_dists[c(1:3,6:8)] else ok_dists[1:3]
-
+  
+  ok_dists <- nlist("normal", student_t = "t", "cauchy", "hs", "hs_plus")
+  ok_intercept_dists <- ok_dists[1:3]
+  
   # Priors for longitudinal submodel(s)
   priorLong_scaled <- priorLong_ops$scaled
   priorLong_min_prior_scale <- priorLong_ops$min_prior_scale
@@ -1152,7 +1297,7 @@ stan_jm <- function(formulaLong, dataLong,
       # !!! Need to change this so that link can be specific to each submodel
       priorLong_scale <- 
         set_prior_scale(priorLong_scale, default = 2.5, 
-                                   link = family[[1]]$link)
+                        link = family[[1]]$link)
     } else {
       priorLong_dist <- ifelse(priorLong_dist == "hs", 3L, 4L)
     }
@@ -1166,6 +1311,7 @@ stan_jm <- function(formulaLong, dataLong,
   }
   
   if (is.null(priorLong_intercept)) {
+    priorLong_informative_for_intercept <- FALSE
     priorLong_dist_for_intercept <- 0L
     priorLong_mean_for_intercept <- as.array(rep(0, sum_y_has_intercept))
     priorLong_scale_for_intercept <- priorLong_df_for_intercept <- as.array(rep(1, sum_y_has_intercept))
@@ -1186,9 +1332,9 @@ stan_jm <- function(formulaLong, dataLong,
         ifelse(priorLong_dist_for_intercept == "normal", 1L, 2L)
       priorLong_scale_for_intercept <- 
         set_prior_scale(priorLong_scale_for_intercept, default = 10, 
-                                   link = family[[1]]$link)      
+                        link = family[[1]]$link)      
     }
-
+    
     priorLong_df_for_intercept <- maybe_broadcast(priorLong_df_for_intercept, sum_y_has_intercept)
     priorLong_df_for_intercept <- as.array(pmin(.Machine$double.xmax, priorLong_df_for_intercept))
     priorLong_mean_for_intercept <- maybe_broadcast(priorLong_mean_for_intercept, sum_y_has_intercept)
@@ -1196,7 +1342,7 @@ stan_jm <- function(formulaLong, dataLong,
     priorLong_scale_for_intercept <- maybe_broadcast(priorLong_scale_for_intercept, sum_y_has_intercept)
     priorLong_scale_for_intercept <- as.array(priorLong_scale_for_intercept)
   }
-
+  
   # Priors for event submodel
   priorEvent_scaled <- priorEvent_ops$scaled
   priorEvent_min_prior_scale <- priorEvent_ops$min_prior_scale
@@ -1227,7 +1373,7 @@ stan_jm <- function(formulaLong, dataLong,
       priorEvent_dist <- ifelse(priorEvent_dist == "normal", 1L, 2L)
       # !!! Need to think about whether 2 is appropriate default value here
       priorEvent_scale <- set_prior_scale(priorEvent_scale, default = 2, 
-                                     link = "none")
+                                          link = "none")
     } else {
       priorEvent_dist <- ifelse(priorEvent_dist == "hs", 3L, 4L)
     }
@@ -1258,13 +1404,13 @@ stan_jm <- function(formulaLong, dataLong,
            paste(names(ok_intercept_dists), collapse = ", "))
     priorEvent_dist_for_intercept <- 
       ifelse(priorEvent_dist_for_intercept == "normal", 1L, 2L)
-    # !!! Need to think about whether 10 is appropriate default value here      
+    # !!! Need to think about whether 50 is appropriate default value here      
     priorEvent_scale_for_intercept <- 
-      set_prior_scale(priorEvent_scale_for_intercept, default = 10, 
+      set_prior_scale(priorEvent_scale_for_intercept, default = 50, 
                       link = "none")
     priorEvent_df_for_intercept <- min(.Machine$double.xmax, priorEvent_df_for_intercept)
   }
-
+  
   # Priors for association parameters
   priorAssoc_scaled <- priorAssoc_ops$scaled  # not currently used
   priorAssoc_min_prior_scale <- priorAssoc_ops$min_prior_scale
@@ -1288,8 +1434,8 @@ stan_jm <- function(formulaLong, dataLong,
       priorAssoc_dist <- ifelse(priorAssoc_dist == "normal", 1L, 2L)
       # !!! Need to potentially have appropriate default value here depending on 
       #     type of association structure
-      priorAssoc_scale <- set_prior_scale(priorAssoc_scale, default = 2, 
-                                     link = "none")      
+      priorAssoc_scale <- set_prior_scale(priorAssoc_scale, default = 25, 
+                                          link = "none")      
     } else {
       priorAssoc_dist <- ifelse(priorAssoc_dist == "hs", 3L, 4L)
     }
@@ -1301,7 +1447,7 @@ stan_jm <- function(formulaLong, dataLong,
     priorAssoc_scale <- maybe_broadcast(priorAssoc_scale, a_K)
     priorAssoc_scale <- as.array(priorAssoc_scale)
   }
-
+  
   # Minimum scaling of priors for longitudinal submodel(s)
   if (priorLong_scaled && priorLong_dist > 0L) {
     for (m in 1:M) {
@@ -1321,45 +1467,45 @@ stan_jm <- function(formulaLong, dataLong,
         if (!QR) 
           priorLong_scale[mark_start:mark_end] <- 
             pmax(priorLong_min_prior_scale, priorLong_scale[mark_start:mark_end] / 
-                 apply(xtemp[[m]], 2L, FUN = function(x) {
-                   num.categories <- length(unique(x))
-                   x.scale <- 1
-                   if (num.categories == 2) x.scale <- diff(range(x))
-                   else if (num.categories > 2) x.scale <- 2 * sd(x)
-                   return(x.scale)
-                 }))      
+                   apply(xtemp[[m]], 2L, FUN = function(x) {
+                     num.categories <- length(unique(x))
+                     x.scale <- 1
+                     if (num.categories == 2) x.scale <- diff(range(x))
+                     else if (num.categories > 2) x.scale <- 2 * sd(x)
+                     return(x.scale)
+                   }))      
       }
-
+      
     }
   }
   priorLong_scale <- as.array(pmin(.Machine$double.xmax, priorLong_scale))
   priorLong_scale_for_intercept <- 
     as.array(pmin(.Machine$double.xmax, priorLong_scale_for_intercept))
-
+  
   # Minimum scaling of priors for event submodel
   if (priorEvent_scaled && priorEvent_dist > 0L) {
     priorEvent_scale <- pmax(priorEvent_min_prior_scale, priorEvent_scale / 
-                          apply(e_xtemp, 2L, FUN = function(x) {
-                            num.categories <- length(unique(x))
-                            e.x.scale <- 1
-                            if (num.categories == 2) e.x.scale <- diff(range(x))
-                            else if (num.categories > 2) e.x.scale <- 2 * sd(x)
-                            return(e.x.scale)
-                          }))
+                               apply(e_xtemp, 2L, FUN = function(x) {
+                                 num.categories <- length(unique(x))
+                                 e.x.scale <- 1
+                                 if (num.categories == 2) e.x.scale <- diff(range(x))
+                                 else if (num.categories > 2) e.x.scale <- 2 * sd(x)
+                                 return(e.x.scale)
+                               }))
   }
   priorEvent_scale <- as.array(pmin(.Machine$double.xmax, priorEvent_scale))
   priorEvent_scale_for_intercept <- 
     min(.Machine$double.xmax, priorEvent_scale_for_intercept)
-
+  
   # Minimum scaling of priors for association parameters    
   if (priorAssoc_dist > 0L) {
     priorAssoc_scale <- pmax(priorAssoc_min_prior_scale, priorAssoc_scale)
   }
   priorAssoc_scale <- as.array(pmin(.Machine$double.xmax, priorAssoc_scale))
-
+  
   # QR not yet implemented for stan_jm  
   if (QR) {
-    stop("QR decomposition is not yet implemented for stan_jm")
+    stop("QR decomposition is not yet supported by stan_jm")
     if (ncol(xtemp) <= 1)
       stop("'QR' can only be specified when there are multiple predictors.")
     cn <- colnames(xtemp)
@@ -1371,11 +1517,11 @@ stan_jm <- function(formulaLong, dataLong,
     colnames(xtemp) <- cn
     xbar <- c(xbar %*% R_inv)
   }
- 
+  
   #=========================
   # Data for export to Stan
   #=========================
-
+  
   standata <- list(  
     # dimensions
     M = as.integer(M),
@@ -1391,7 +1537,7 @@ stan_jm <- function(formulaLong, dataLong,
     sum_y_K = as.integer(sum_y_K),
     e_K = as.integer(e_K),
     a_K = as.integer(a_K),
-    quadnodes = quadnodes,
+    quadnodes = as.integer(quadnodes),
     Npat_times_quadnodes = as.integer(Npat * quadnodes),
     sum_y_has_intercept = as.integer(sum_y_has_intercept), 
     sum_y_has_intercept_unbound = as.integer(sum_y_has_intercept_unbound), 
@@ -1438,18 +1584,38 @@ stan_jm <- function(formulaLong, dataLong,
     e_xbar = if (centreEvent) as.array(e_xbar) else double(0),
     e_weights = as.array(e_weights),
     e_weights_rep = as.array(e_weights_rep),
-    quadweight_times_half_eventtime = weights_times_half_eventtime,
+    quadweight = as.array(quadweight),
     
     # data for association structure
     assoc = as.integer(a_K > 0L),
     has_assoc_ev = as.array(as.integer(has_assoc$etavalue)),
     has_assoc_es = as.array(as.integer(has_assoc$etaslope)),
-    has_assoc_cv = as.array(as.integer(has_assoc$muvalue)),
-    has_assoc_cs = as.array(as.integer(has_assoc$muslope)),
+    has_assoc_el = as.array(as.integer(has_assoc$etalag)),
+    has_assoc_ea = as.array(as.integer(has_assoc$etaauc)),
+    has_assoc_mv = as.array(as.integer(has_assoc$muvalue)),
+    has_assoc_ms = as.array(as.integer(has_assoc$muslope)),
+    has_assoc_ml = as.array(as.integer(has_assoc$mulag)),
+    has_assoc_ma = as.array(as.integer(has_assoc$muauc)),
+    has_assoc_evi = as.array(as.integer(has_assoc$etavalue_interact)),
+    has_assoc_esi = as.array(as.integer(has_assoc$etaslope_interact)),
+    has_assoc_mvi = as.array(as.integer(has_assoc$muvalue_interact)),
+    has_assoc_msi = as.array(as.integer(has_assoc$muslope_interact)),    
     sum_has_assoc_ev = as.integer(sum(has_assoc$etavalue)),
     sum_has_assoc_es = as.integer(sum(has_assoc$etaslope)),
-    sum_has_assoc_cv = as.integer(sum(has_assoc$muvalue)),
-    sum_has_assoc_cs = as.integer(sum(has_assoc$muslope)),
+    sum_has_assoc_el = as.integer(sum(has_assoc$etalag)),
+    sum_has_assoc_ea = as.integer(sum(has_assoc$etaauc)),
+    sum_has_assoc_mv = as.integer(sum(has_assoc$muvalue)),
+    sum_has_assoc_ms = as.integer(sum(has_assoc$muslope)),
+    sum_has_assoc_ml = as.integer(sum(has_assoc$mulag)),
+    sum_has_assoc_ma = as.integer(sum(has_assoc$muauc)),
+    sum_has_assoc_evi = as.integer(sum(has_assoc$etavalue_interact)),
+    sum_has_assoc_esi = as.integer(sum(has_assoc$etaslope_interact)),
+    sum_has_assoc_mvi = as.integer(sum(has_assoc$muvalue_interact)),
+    sum_has_assoc_msi = as.integer(sum(has_assoc$muslope_interact)),
+    auc_quadnodes = as.integer(auc_quadnodes),
+    auc_quadweight = as.array(auc_quadweight),
+    nrow_y_Xq_auc = as.integer(auc_quadnodes * NROW(xqtemp[[1]])),
+    Npat_times_auc_quadnodes = as.integer(Npat * auc_quadnodes),
     sum_size_which_b = as.integer(sum(size_which_b)),
     size_which_b = as.array(size_which_b),
     which_b_zindex = as.array(unlist(which_b_zindex)),
@@ -1494,9 +1660,9 @@ stan_jm <- function(formulaLong, dataLong,
   
   # data for random effects
   group <- lapply(1:M, function(x) {
-                    pad_reTrms(Ztlist = Ztlist[[x]], 
-                               cnms = y_cnms[[x]], 
-                               flist = y_flist[[x]])})
+    pad_reTrms(Ztlist = Ztlist[[x]], 
+               cnms = y_cnms[[x]], 
+               flist = y_flist[[x]])})
   Z     <- lapply(1:M, function(x) group[[x]]$Z)
   y_cnms <- lapply(1:M, function(x) group[[x]]$cnms)
   y_flist_padded <- lapply(1:M, function(x) group[[x]]$flist)
@@ -1538,7 +1704,7 @@ stan_jm <- function(formulaLong, dataLong,
         b_nms <- c(b_nms, paste0("Long", m, "|", nms_i, ":", levels(y_flist_padded[[m]][[nm]])))
       } else {
         b_nms <- c(b_nms, c(t(sapply(nms_i, function(x) 
-                          paste0("Long", m, "|", x, ":", levels(y_flist_padded[[m]][[nm]]))))))
+          paste0("Long", m, "|", x, ":", levels(y_flist_padded[[m]][[nm]]))))))
       }
       g_nms <- c(g_nms, paste0("Long", m, "|", nms_i)) 
     }
@@ -1559,7 +1725,7 @@ stan_jm <- function(formulaLong, dataLong,
   standata$w <- parts$w
   standata$v <- parts$v
   standata$u <- as.array(parts$u)
- 
+  
   # data for random effects in GK quadrature
   groupq <- lapply(1:M, function(x) {
     pad_reTrms(Ztlist = Ztlistq[[x]], 
@@ -1572,7 +1738,7 @@ stan_jm <- function(formulaLong, dataLong,
   standata$w_Zq <- parts_Zq$w
   standata$v_Zq <- parts_Zq$v
   standata$u_Zq <- as.array(parts_Zq$u)
-
+  
   # data for calculating eta slope in GK quadrature 
   standata$eps <- eps  # time shift for numerically calculating derivative
   standata$y_Xq_eps <- if (sum(has_assoc$etaslope, has_assoc$muslope))
@@ -1580,8 +1746,8 @@ stan_jm <- function(formulaLong, dataLong,
   if (length(Ztlistq_eps)) {
     groupq_eps <- lapply(1:M, function(x) {
       pad_reTrms(Ztlist = Ztlistq_eps[[x]], 
-                cnms = y_cnmsq_eps[[x]], 
-                flist = y_flistq_eps[[x]])})
+                 cnms = y_cnmsq_eps[[x]], 
+                 flist = y_flistq_eps[[x]])})
     Zq_eps <- lapply(1:M, function(x) groupq_eps[[x]]$Z)
     Zq_eps_merge <- Matrix::bdiag(Zq_eps) 
   } else Zq_eps_merge <- matrix(0,0,0)
@@ -1590,6 +1756,45 @@ stan_jm <- function(formulaLong, dataLong,
   standata$w_Zq_eps <- parts_Zq_eps$w
   standata$v_Zq_eps <- parts_Zq_eps$v
   standata$u_Zq_eps <- as.array(parts_Zq_eps$u)    
+  
+  # data for calculating eta lag in GK quadrature 
+  standata$y_Xq_lag <- if (sum(has_assoc$etalag, has_assoc$mulag))
+    as.array(as.matrix(Matrix::bdiag(xqtemp_lag))) else as.array(matrix(0,0,sum_y_K))
+  if (length(Ztlistq_lag)) {
+    groupq_lag <- lapply(1:M, function(x) {
+      pad_reTrms(Ztlist = Ztlistq_lag[[x]], 
+                 cnms = y_cnmsq_lag[[x]], 
+                 flist = y_flistq_lag[[x]])})
+    Zq_lag <- lapply(1:M, function(x) groupq_lag[[x]]$Z)
+    Zq_lag_merge <- Matrix::bdiag(Zq_lag) 
+  } else Zq_lag_merge <- matrix(0,0,0)
+  parts_Zq_lag <- rstan::extract_sparse_parts(Zq_lag_merge)
+  standata$num_non_zero_Zq_lag <- as.integer(length(parts_Zq_lag$w))
+  standata$w_Zq_lag <- parts_Zq_lag$w
+  standata$v_Zq_lag <- parts_Zq_lag$v
+  standata$u_Zq_lag <- as.array(parts_Zq_lag$u)    
+  
+  # data for calculating eta auc in GK quadrature 
+  standata$y_Xq_auc <- if (sum(has_assoc$etaauc, has_assoc$muauc))
+    as.array(as.matrix(Matrix::bdiag(xqtemp_auc))) else as.array(matrix(0,0,sum_y_K))
+  if (length(Ztlistq_auc)) {
+    groupq_auc <- lapply(1:M, function(x) {
+      pad_reTrms(Ztlist = Ztlistq_auc[[x]], 
+                 cnms = y_cnmsq_auc[[x]], 
+                 flist = y_flistq_auc[[x]])})
+    Zq_auc <- lapply(1:M, function(x) groupq_auc[[x]]$Z)
+    Zq_auc_merge <- Matrix::bdiag(Zq_auc) 
+  } else Zq_auc_merge <- matrix(0,0,0)
+  parts_Zq_auc <- rstan::extract_sparse_parts(Zq_auc_merge)
+  standata$num_non_zero_Zq_auc <- as.integer(length(parts_Zq_auc$w))
+  standata$w_Zq_auc <- parts_Zq_auc$w
+  standata$v_Zq_auc <- parts_Zq_auc$v
+  standata$u_Zq_auc <- as.array(parts_Zq_auc$u)    
+  
+  # data for calculating interactions in GK quadrature 
+  standata$y_Xq_int <- as.array(t(as.matrix(do.call("cbind", (xqtemp_int)))))
+  standata$a_K_int <- as.array(unlist(a_K_int))  # number of columns in xqtemp_int corresponding to each interaction type (etavalue, etaslope, muvalue, muslope) for each submodel
+  standata$sum_a_K_int <-  as.integer(sum(unlist(a_K_int)))
   
   # hyperparameters for random effects model
   if (prior_covariance$dist == "decov") {
@@ -1602,28 +1807,24 @@ stan_jm <- function(formulaLong, dataLong,
     standata$len_regularization <- sum(p > 1)
     standata$regularization <- 
       as.array(maybe_broadcast(decov_args$regularization, sum(p > 1))) 
-  } else if (prior_covariance$dist == "lkjcorr") {
-    lkj_args <- prior_covariance
-    standata$lkj_shape <- as.array(maybe_broadcast(lkj_args$shape, t))
-    standata$prior_scale_for_sd_b <- as.array(maybe_broadcast(lkj_args$scale, sum(p)))
   }
-
+  
   standata$family <- as.array(sapply(1:M, function(x) {
-                       return_fam <- switch(family[[x]]$family, 
-                            gaussian = 1L, 
-                            Gamma = 2L,
-                            inverse.gaussian = 3L,
-                            binomial = 5L,
-                            poisson = 6L,
-                            "neg_binomial_2" = 7L)
-                       if (is_bernoulli[[x]]) return_fam <- 4L
-                       return_fam}))
+    return_fam <- switch(family[[x]]$family, 
+                         gaussian = 1L, 
+                         Gamma = 2L,
+                         inverse.gaussian = 3L,
+                         binomial = 5L,
+                         poisson = 6L,
+                         "neg_binomial_2" = 7L)
+    if (is_bernoulli[[x]]) return_fam <- 4L
+    return_fam}))
   standata$any_fam_3 <- as.integer(any(standata$family == 3L))
   
   # B-splines baseline hazard
   standata$e_ns_times <- if (base_haz_bs) 
     as.array(predict(bs_basis, standata$e_times)) else 
-    as.array(matrix(0,0,0))
+      as.array(matrix(0,0,0))
   
   # Piecewise constant baseline hazard
   if (base_haz_piecewise) {
@@ -1634,12 +1835,12 @@ stan_jm <- function(formulaLong, dataLong,
   }
   standata$e_times_piecedummy <- if (base_haz_piecewise)
     as.array(tmp) else as.array(matrix(0,0,0))    
-
+  
   
   #================
   # Initial values
   #================
- 
+  
   if (init == "model_based") {
     y_gamma_unbound <- unlist(y_gamma_unbound)
     y_gamma_lobound <- unlist(y_gamma_lobound)
@@ -1647,17 +1848,17 @@ stan_jm <- function(formulaLong, dataLong,
     y_z_beta <- (unlist(y_beta) - priorLong_mean) / priorLong_scale
     y_dispersion_unscaled <- y_dispersion / priorLong_scale_for_dispersion
     e_z_beta <- (e_beta - priorEvent_mean) / priorEvent_scale 
-
+    
     y_hs <- if (priorLong_dist <= 2L) 0 
-            else if (priorLong_dist == 3L) 2
-            else if (priorLong_dist == 4L) 4
+    else if (priorLong_dist == 3L) 2
+    else if (priorLong_dist == 4L) 4
     e_hs <- if (priorEvent_dist <= 2L) 0 
-            else if (priorEvent_dist == 3L) 2
-            else if (priorEvent_dist == 4L) 4
+    else if (priorEvent_dist == 3L) 2
+    else if (priorEvent_dist == 4L) 4
     a_hs <- if (priorAssoc_dist <= 2L) 0 
-            else if (priorAssoc_dist == 3L) 2
-            else if (priorAssoc_dist == 4L) 4
-
+    else if (priorAssoc_dist == 3L) 2
+    else if (priorAssoc_dist == 4L) 4
+    
     if (prior_covariance$dist == "decov") {
       len_z_T <- 0
       for (i in 1:t) {
@@ -1690,44 +1891,44 @@ stan_jm <- function(formulaLong, dataLong,
     
     model_based_inits <- Filter(function(x) (!is.null(x)), c(
       list(
-      y_gamma_unbound = if (sum_y_has_intercept_unbound) as.array(y_gamma_unbound) else double(0),
-      y_gamma_lobound = if (sum_y_has_intercept_lobound) as.array(y_gamma_lobound) else double(0),
-      y_gamma_upbound = if (sum_y_has_intercept_upbound) as.array(y_gamma_upbound) else double(0),
-      y_z_beta = if (sum_y_K) as.array(y_z_beta) else double(0),
-      y_dispersion_unscaled = if (sum_y_has_dispersion) as.array(y_dispersion_unscaled) else double(0),
-      e_gamma = if (e_has_intercept) as.array(0) else double(0),
-      e_z_beta = if (e_K) as.array(e_z_beta) else double(0),
-      weibull_shape_unscaled = if (base_haz_weibull) 
-        as.array(runif(1, 0.5, 3) / priorEvent_scale_for_weibull) else double(0),
-      bs_coefs_unscaled = if (base_haz_bs) as.array(rep(0, bs_df)) else double(0),
-      piecewise_coefs_unscaled = if (base_haz_piecewise) as.array(rep(0, piecewise_df)) else double(0),
-      a_z_beta = if (a_K) as.array(rep(0, a_K)) else double(0),
-      z_b = as.array(runif(standata$len_b, -0.5, 0.5)),
-      y_global = as.array(runif(y_hs)),
-      y_local = if (y_hs) matrix(runif(y_hs * sum_y_K), nrow = y_hs, ncol = sum_y_K)
+        y_gamma_unbound = if (sum_y_has_intercept_unbound) as.array(y_gamma_unbound) else double(0),
+        y_gamma_lobound = if (sum_y_has_intercept_lobound) as.array(y_gamma_lobound) else double(0),
+        y_gamma_upbound = if (sum_y_has_intercept_upbound) as.array(y_gamma_upbound) else double(0),
+        y_z_beta = if (sum_y_K) as.array(y_z_beta) else double(0),
+        y_dispersion_unscaled = if (sum_y_has_dispersion) as.array(y_dispersion_unscaled) else double(0),
+        e_gamma = if (e_has_intercept) as.array(0) else double(0),
+        e_z_beta = if (e_K) as.array(e_z_beta) else double(0),
+        weibull_shape_unscaled = if (base_haz_weibull) 
+          as.array(runif(1, 0.5, 3) / priorEvent_scale_for_weibull) else double(0),
+        bs_coefs_unscaled = if (base_haz_bs) as.array(rep(0, bs_df)) else double(0),
+        piecewise_coefs_unscaled = if (base_haz_piecewise) as.array(rep(0, piecewise_df)) else double(0),
+        a_z_beta = if (a_K) as.array(rep(0, a_K)) else double(0),
+        z_b = as.array(runif(standata$len_b, -0.5, 0.5)),
+        y_global = as.array(runif(y_hs)),
+        y_local = if (y_hs) matrix(runif(y_hs * sum_y_K), nrow = y_hs, ncol = sum_y_K)
         else matrix(0,0,0),
-      e_global = as.array(runif(e_hs)),
-      e_local = if (e_hs) matrix(runif(e_hs * e_K), nrow = e_hs, ncol = e_K)
+        e_global = as.array(runif(e_hs)),
+        e_local = if (e_hs) matrix(runif(e_hs * e_K), nrow = e_hs, ncol = e_K)
         else matrix(0,0,0),
-      a_global = as.array(runif(a_hs)),
-      a_local = if (a_hs) matrix(runif(a_hs * a_K), nrow = a_hs, ncol = a_K)
+        a_global = as.array(runif(a_hs)),
+        a_local = if (a_hs) matrix(runif(a_hs * a_K), nrow = a_hs, ncol = a_K)
         else matrix(0,0,0)      
       ),
       if (prior_covariance$dist == "decov") list(
-      z_T = as.array(rep(sqrt(1/len_z_T), len_z_T)),
-      rho = if ((sum(p) - t) > 0) as.array(rep(1 / (sum(p) - t + 1), (sum(p) - t))) else double(0),
-      zeta = if (!is.null(normalised_zetas)) as.array(normalised_zetas) else double(0),
-      tau = as.array(tau)
+        z_T = as.array(rep(sqrt(1/len_z_T), len_z_T)),
+        rho = if ((sum(p) - t) > 0) as.array(rep(1 / (sum(p) - t + 1), (sum(p) - t))) else double(0),
+        zeta = if (!is.null(normalised_zetas)) as.array(normalised_zetas) else double(0),
+        tau = as.array(tau)
       )
     ))
     init <- function() model_based_inits
   }
-
-
+  
+  
   #===========
   # Fit model
   #===========
-
+    
   # call stan() to draw from posterior distribution
   stanfit <- stanmodels$jm
   pars <- c(if (sum_y_has_intercept_unbound) "y_gamma_unbound",
@@ -1745,12 +1946,12 @@ stan_jm <- function(formulaLong, dataLong,
             if (base_haz_weibull) "weibull_shape",
             if (base_haz_piecewise) "piecewise_coefs",
             if (base_haz_bs) "bs_coefs")
-
+  
   cat(paste0(if (M == 1L) "Uni" else "Multi", 
              "variate joint model specified\n"))
   if (algorithm == "sampling") {
     cat("\nPlease note the warmup phase may be much slower than",
-      "later iterations!\n")             
+        "later iterations!\n")             
     sampling_args <- set_sampling_args_for_jm(
       object = stanfit, 
       user_dots = list(...), 
@@ -1768,41 +1969,49 @@ stan_jm <- function(formulaLong, dataLong,
                          algorithm = algorithm, ...)    
   }
   
-#  if (QR) {  # not yet implemented for stan_jm
-#    thetas <- extract(stanfit, pars = "beta", inc_warmup = TRUE, 
-#                      permuted = FALSE)
-#    betas <- apply(thetas, 1:2, FUN = function(theta) R_inv %*% theta)
-#    end <- utils::tail(dim(betas), 1L)
-#    for (chain in 1:end) for (param in 1:nrow(betas)) {
-#      stanfit@sim$samples[[chain]][[has_intercept + param]] <-
-#        if (ncol(xtemp) > 1) betas[param, , chain] else betas[param, chain]
-#    }
-#  }
-
+  #  if (QR) {  # not yet implemented for stan_jm
+  #    thetas <- extract(stanfit, pars = "beta", inc_warmup = TRUE, 
+  #                      permuted = FALSE)
+  #    betas <- apply(thetas, 1:2, FUN = function(theta) R_inv %*% theta)
+  #    end <- utils::tail(dim(betas), 1L)
+  #    for (chain in 1:end) for (param in 1:nrow(betas)) {
+  #      stanfit@sim$samples[[chain]][[has_intercept + param]] <-
+  #        if (ncol(xtemp) > 1) betas[param, , chain] else betas[param, chain]
+  #    }
+  #  }
+  
   # Names for coefs from submodel(s)
   int_nms <- unlist(lapply(1:M, function(x) 
-                    if (y_has_intercept[x]) paste0("Long", x, "|(Intercept)")))
+    if (y_has_intercept[x]) paste0("Long", x, "|(Intercept)")))
   y_nms   <- unlist(lapply(1:M, function(x) 
-                    if (ncol(xtemp[[x]])) paste0("Long", x, "|", colnames(xtemp[[x]]))))
+    if (ncol(xtemp[[x]])) paste0("Long", x, "|", colnames(xtemp[[x]]))))
   e_nms   <- if (ncol(e_x)) paste0("Event|", colnames(e_x))    
   
   # Names for vector of association parameters
   a_nms <- character()  
   for (m in 1:M) {
-    if (has_assoc$etavalue[m]) a_nms <- c(a_nms, paste0("Assoc|Long", m,":eta-value"))
-    if (has_assoc$muvalue[m]) a_nms <- c(a_nms, paste0("Assoc|Long", m,":mu-value"))
-    if (has_assoc$etaslope[m]) a_nms <- c(a_nms, paste0("Assoc|Long", m,":eta-slope"))
-    if (has_assoc$muslope[m]) a_nms <- c(a_nms, paste0("Assoc|Long", m,":mu-slope"))
+    if (has_assoc$etavalue[m]) a_nms <- c(a_nms, paste0("Assoc|Long", m,"|etavalue"))
+    if (has_assoc$etavalue_interact[m]) a_nms <- c(a_nms, paste0("Assoc|Long", m,"|etavalue:", colnames(xq_int[[m]][["etavalue_interact"]])))
+    if (has_assoc$etaslope[m]) a_nms <- c(a_nms, paste0("Assoc|Long", m,"|etaslope"))
+    if (has_assoc$etaslope_interact[m]) a_nms <- c(a_nms, paste0("Assoc|Long", m,"|etaslope:", colnames(xq_int[[m]][["etaslope_interact"]])))    
+    if (has_assoc$etalag[m]) a_nms <- c(a_nms, paste0("Assoc|Long", m,"|etalag"))
+    if (has_assoc$etaauc[m]) a_nms <- c(a_nms, paste0("Assoc|Long", m,"|etaauc"))
+    if (has_assoc$muvalue[m]) a_nms <- c(a_nms, paste0("Assoc|Long", m,"|muvalue"))
+    if (has_assoc$muvalue_interact[m]) a_nms <- c(a_nms, paste0("Assoc|Long", m,"|muvalue:", colnames(xq_int[[m]][["muvalue_interact"]])))    
+    if (has_assoc$muslope[m]) a_nms <- c(a_nms, paste0("Assoc|Long", m,"|muslope"))
+    if (has_assoc$muslope_interact[m]) a_nms <- c(a_nms, paste0("Assoc|Long", m,"|muslope:", colnames(xq_int[[m]][["muslope_interact"]])))    
+    if (has_assoc$mulag[m]) a_nms <- c(a_nms, paste0("Assoc|Long", m,"|mulag"))
+    if (has_assoc$muauc[m]) a_nms <- c(a_nms, paste0("Assoc|Long", m,"|muauc"))
   }
   if (sum(size_which_b)) {
     temp_g_nms <- lapply(1:M, FUN = function(m) {
-      all_nms <- paste0(paste0("Long", m, ":b["), y_cnms[[m]][[id_var]], "]")
+      all_nms <- paste0(paste0("Long", m, "|b["), y_cnms[[m]][[id_var]], "]")
       all_nms[which_b_zindex[[m]]]})
     a_nms <- c(a_nms, paste0("Assoc|", unlist(temp_g_nms)))
   }
   if (sum(size_which_coef)) {
     temp_g_nms <- lapply(1:M, FUN = function(m) {
-      all_nms <- paste0(paste0("Long", m, ":coef["), y_cnms[[m]][[id_var]], "]")
+      all_nms <- paste0(paste0("Long", m, "|coef["), y_cnms[[m]][[id_var]], "]")
       all_nms[which_coef_zindex[[m]]]})
     a_nms <- c(a_nms, paste0("Assoc|", unlist(temp_g_nms)))
   }
@@ -1815,7 +2024,7 @@ stan_jm <- function(formulaLong, dataLong,
     else if (is.ig(famname[[m]]))    d_nms <- c(d_nms, paste0("Long", m,"|lambda"))
     else if (is.nb(famname[[m]]))    d_nms <- c(d_nms, paste0("Long", m,"|overdispersion"))
   }
-                  
+  
   new_names <- c(int_nms,
                  y_nms,
                  e_nms,
@@ -1824,8 +2033,7 @@ stan_jm <- function(formulaLong, dataLong,
                  d_nms,
                  if (base_haz_weibull) "Event|weibull-shape",               
                  if (base_haz_piecewise) paste0("Event|basehaz-coef", seq(piecewise_df)),               
-                 if (base_haz_bs) paste0("Event|basehaz-coef", seq(bs_df)),               
-                 paste0("theta_L", seq(standata$len_theta_L)),
+                 if (base_haz_bs) paste0("Event|basehaz-coef", seq(bs_df)),
                  "log-posterior")
   stanfit@sim$fnames_oi <- new_names
   
@@ -1839,7 +2047,7 @@ stan_jm <- function(formulaLong, dataLong,
   } else if (base_haz_piecewise) {
     attr <- list(df = piecewise_df, knots = knots)
   } else attr <- NULL
-
+  
   # Undo ordering of matrices if bernoulli
   for (m in 1:M) {
     if (is_bernoulli[[m]]) {
@@ -1853,23 +2061,24 @@ stan_jm <- function(formulaLong, dataLong,
   
   #colnames(Z) <- b_names(names(stanfit), value = TRUE)
   fit <- nlist(stanfit, family, formula = c(formulaLong, formulaEvent), 
-                          id_var, time_var, offset = NULL, quadnodes,
-                          base_haz = list(type = base_haz, attr = attr),
-                          M, cnms, y_N, y_cnms, y_flist, Npat, n_grps, assoc = has_assoc, 
-                          fr = c(y_fr, list(e_fr)),
-                          x = lapply(1:M, function(i) 
-                            if (getRversion() < "3.2.0") Matrix::cBind(x[[i]], Z[[i]]) else cbind2(x[[i]], Z[[i]])),
-                          xq = lapply(1:M, function(i) 
-                            if (getRversion() < "3.2.0") Matrix::cBind(xq[[i]], Zq[[i]]) else cbind2(xq[[i]], Zq[[i]])),                 
-                          xq_eps = lapply(1:M, function(i) 
-                            if (has_assoc$etaslope[m] || has_assoc$muslope[m]) {
-                              if (getRversion() < "3.2.0") 
-                                Matrix::cBind(xq_eps[[i]], Zq_eps[[i]]) else cbind2(xq_eps[[i]], Zq_eps[[i]])
-                            } else NULL),                          
-                          y = y, e_x, eventtime, d, quadpoints = quadpoint, 
-                          epsilon = if (sum(has_assoc$etaslope, has_assoc$muslope)) eps else NULL,
-                          standata, dataLong, dataEvent, call, terms = NULL, model = NULL,
-                          na.action, algorithm = "sampling", init, glmod = y_mod, coxmod = e_mod)
+               id_var, time_var, offset = NULL, quadnodes,
+               base_haz = list(type = base_haz, attr = attr),
+               M, cnms, y_N, y_cnms, y_flist, Npat, n_grps, assoc = lapply(has_assoc, as.logical), 
+               fr = c(y_fr, list(e_fr)),
+               x = lapply(1:M, function(i) 
+                 if (getRversion() < "3.2.0") Matrix::cBind(x[[i]], Z[[i]]) else cbind2(x[[i]], Z[[i]])),
+               xq = lapply(1:M, function(i) 
+                 if (getRversion() < "3.2.0") Matrix::cBind(xq[[i]], Zq[[i]]) else cbind2(xq[[i]], Zq[[i]])),                 
+               xq_eps = lapply(1:M, function(i) 
+                 if (has_assoc$etaslope[m] || has_assoc$muslope[m]) {
+                   if (getRversion() < "3.2.0") 
+                     Matrix::cBind(xq_eps[[i]], Zq_eps[[i]]) else cbind2(xq_eps[[i]], Zq_eps[[i]])
+                 } else NULL),                          
+               y = y, e_x, eventtime, d, quadpoints = quadpoint, 
+               epsilon = if (sum(has_assoc$etaslope, has_assoc$muslope)) eps else NULL,
+               standata, dataLong, dataEvent, call, terms = NULL, model = NULL,                          
+               prior.info = get_prior_info(call, formals()),
+               na.action, algorithm = "sampling", init, glmod = y_mod, coxmod = e_mod)
   out <- stanjm(fit)
   
   return(out)
@@ -1959,10 +2168,10 @@ check_id_var <- function(id_var, y_cnms) {
       stop("The grouping factor (ie, subject ID variable) is not the ",
            "same in all longitudinal submodels", call. = FALSE)
     if ((!is.null(id_var)) && (!identical(id_var, only_cnm)))
-        warning("The user specified 'id_var' (", paste(id_var), 
-                ") and the assumed ID variable based on the single ",
-                "grouping factor (", paste(only_cnm), ") are not the same; ", 
-                "'id_var' will be ignored", call. = FALSE, immediate. = TRUE)
+      warning("The user specified 'id_var' (", paste(id_var), 
+              ") and the assumed ID variable based on the single ",
+              "grouping factor (", paste(only_cnm), ") are not the same; ", 
+              "'id_var' will be ignored", call. = FALSE, immediate. = TRUE)
     return(only_cnm)
   }
 }
@@ -1994,11 +2203,20 @@ check_id_list <- function(id_var, y_flist) {
 # @return A list of logicals indicating the desired association types
 validate_assoc <- function(m, x, y_cnms, supported_assocs, id_var, xmat) {
   
+  # Select association structure for submodel m only
+  # 'x_tmp' will be changed in code below, whilst 'x' stays equal to user input
+  x_tmp <- x <- x[[m]]
+  
   # Identify which association types were specified
-  x_tmp <- x[[m]]
   if (!is.null(x_tmp)) {
+    x_tmp <- gsub("^etalag\\(.*", "etalag", x_tmp) 
+    x_tmp <- gsub("^mulag\\(.*", "mulag", x_tmp) 
     x_tmp <- gsub("^shared_b.*", "shared_b", x_tmp) 
     x_tmp <- gsub("^shared_coef\\(.*", "shared_coef", x_tmp) 
+    x_tmp <- gsub("^etavalue_interact\\(.*", "etavalue_interact", x_tmp) 
+    x_tmp <- gsub("^muvalue_interact\\(.*", "muvalue_interact", x_tmp) 
+    x_tmp <- gsub("^etaslope_interact\\(.*", "etaslope_interact", x_tmp) 
+    x_tmp <- gsub("^muslope_interact\\(.*", "muslope_interact", x_tmp) 
   }
   assoc <- sapply(supported_assocs, function(y) y %in% x_tmp, simplify = FALSE)
   if (is.null(x_tmp)) {
@@ -2016,14 +2234,72 @@ validate_assoc <- function(m, x, y_cnms, supported_assocs, id_var, xmat) {
            "together", call. = FALSE)
     if (assoc$etaslope && assoc$muslope)
       stop("In 'assoc' argument, 'etaslope' and 'muslope' cannot be specified ",
-           "together", call. = FALSE)    
+           "together", call. = FALSE)   
+    if (assoc$etavalue && assoc$muvalue)
+      stop("In 'assoc' argument, 'etalag' and 'mulag' cannot be specified ",
+           "together", call. = FALSE)
   } else { 
     stop("'assoc' argument should be a character vector or, for a multivariate ",
          "joint model, possibly a list of character vectors.", call. = FALSE)
   }
   
+  # Identify which lags were requested
+  if (assoc$etalag || assoc$mulag) {
+    if (assoc$etalag) {
+      val_etalag <- grep("^etalag.*", x, value = TRUE)
+      val_lag <- unlist(strsplit(val_etalag, "etalag"))[-1]
+    } else if (assoc$mulag) {
+      val_mulag <- grep("^mulag.*", x, value = TRUE)
+      val_lag <- unlist(strsplit(val_mulag, "mulag"))[-1]
+    }
+    if (length(val_lag)) {
+      assoc$which_lag <- tryCatch(eval(parse(text = paste0("c", val_lag))), 
+                                  error = function(x) 
+                                    stop("Incorrect specification of the lagged ",
+                                         "association structure. See Examples in help ",
+                                         "file.", call. = FALSE))
+      if (length(assoc$which_lag) > 1L) 
+        stop("Currently only one lag time is allowed for the lagged association ",
+             "structure.", call. = FALSE)
+    } else {
+      stop("'etalag' association structure was specified incorrectly. It should ",
+           "include a suffix with the desired lag inside parentheses. See the ",
+           "help file for details.", call. = FALSE)    
+    }    
+  } else assoc$which_lag <- 0  
+  
+  # Check interaction formula was specified correctly
+  if (any(assoc$etavalue_interact, assoc$muvalue_interact, 
+          assoc$etaslope_interact, assoc$muslope_interact)) {
+    assoc$formula_interact <- sapply(c("etavalue_interact", "muvalue_interact",
+                                       "etaslope_interact", "muslope_interact"),
+                                     function(y, x) {
+                                       if (assoc[[y]]) {
+                                         val <- grep(paste0("^", y, ".*"), x, value = TRUE)
+                                         val <- unlist(strsplit(val, y))[-1]
+                                         fm <- tryCatch(eval(parse(text = val)), 
+                                                        error = function(e) 
+                                                          stop(paste0("Incorrect specification of the formula in the '", y,
+                                                                      "' association structure. See Examples in help ",
+                                                                      "file."), call. = FALSE))
+                                         if (!is(fm, "formula"))
+                                           stop(paste0("Suffix to '", y, "' association structure should include ",
+                                                       "a formula within parentheses."), call. = FALSE)
+                                         if (identical(length(fm), 3L))
+                                           stop(paste0("Formula specified for '", y, "' association structure should not ",
+                                                       "include a response."), call. = FALSE)
+                                         if (length(lme4::findbars(fm)))
+                                           stop(paste0("Formula specified for '", y, "' association structure should only ",
+                                                       "include fixed effects."), call. = FALSE)
+                                         if (fm[[2L]] == 1)
+                                           stop(paste0("Formula specified for '", y, "' association structure cannot ",
+                                                       "be an intercept only."), call. = FALSE)
+                                         fm
+                                       } else NULL
+                                     }, x = x, simplify = FALSE, USE.NAMES = TRUE)
+  } else assoc$formula_interact <- NULL  # no interaction assoc at all for submodel m
+  
   # Identify which subset of shared random effects were specified
-  x <- x[[m]]
   max_which_b_zindex <- length(y_cnms[[m]][[id_var]])
   val_b <- grep("^shared_b.*", x, value = TRUE)
   val_coef <- grep("^shared_coef.*", x, value = TRUE)
@@ -2032,10 +2308,10 @@ validate_assoc <- function(m, x, y_cnms, supported_assocs, id_var, xmat) {
     val_b <- unlist(strsplit(val_b, "shared_b"))[-1]
     if (length(val_b)) {
       assoc$which_b_zindex <- tryCatch(eval(parse(text = paste0("c", val_b))), 
-                              error = function(x) 
-                                stop("Incorrect specification of the 'shared_b' ",
-                                     "association structure. See Examples in help ",
-                                     "file.", call. = FALSE))
+                                       error = function(x) 
+                                         stop("Incorrect specification of the 'shared_b' ",
+                                              "association structure. See Examples in help ",
+                                              "file.", call. = FALSE))
     } else assoc$which_b_zindex <- seq_len(max_which_b_zindex)
     if (any(assoc$which_b_zindex > max_which_b_zindex))
       stop(paste0("The indices specified for the shared random effects association ",
@@ -2044,15 +2320,15 @@ validate_assoc <- function(m, x, y_cnms, supported_assocs, id_var, xmat) {
                   ")"), call. = FALSE)
     names(assoc$which_b_zindex) <- y_cnms[[m]][[id_var]][assoc$which_b_zindex]
   } else assoc$which_b_zindex <- numeric(0)
-
+  
   if (length(val_coef)) {
     val_coef <- unlist(strsplit(val_coef, "shared_coef"))[-1]
     if (length(val_coef)) {
       assoc$which_coef_zindex <- tryCatch(eval(parse(text = paste0("c", val_coef))), 
-                                error = function(x) 
-                                  stop("Incorrect specification of the 'shared_coef' ",
-                                       "association structure. See Examples in help ",
-                                       "file.", call. = FALSE))
+                                          error = function(x) 
+                                            stop("Incorrect specification of the 'shared_coef' ",
+                                                 "association structure. See Examples in help ",
+                                                 "file.", call. = FALSE))
     } else assoc$which_coef_zindex <- seq_len(max_which_b_zindex)
     if (any(assoc$which_coef_zindex > max_which_b_zindex))
       stop(paste0("The indices specified for the shared random effects association ",
@@ -2060,12 +2336,12 @@ validate_assoc <- function(m, x, y_cnms, supported_assocs, id_var, xmat) {
                   "effects (this error was encountered for longitudinal submodel ", m,
                   ")"), call. = FALSE)
   } else assoc$which_coef_zindex <- numeric(0)  
-
+  
   if (length(intersect(assoc$which_b_zindex, assoc$which_coef_zindex)))
     stop("The same random effects indices should not be specified in both ",
          "'shared_b' and 'shared_coef'. Specifying indices in 'shared_coef' ",
          "will include both the fixed and random components.", call. = FALSE)
-
+  
   if (length(assoc$which_coef_zindex)) {
     if (length(y_cnms[[m]]) > 1L)
       stop("'shared_coef' association structure cannot be used when there is ",
@@ -2093,7 +2369,7 @@ validate_assoc <- function(m, x, y_cnms, supported_assocs, id_var, xmat) {
   if (!identical(length(assoc$which_coef_zindex), length(assoc$which_coef_xindex)))
     stop("Bug found: the lengths of the fixed and random components of the ",
          "'shared_coef' association structure are not the same.")
-  
+
   assoc
 }
 
@@ -2341,7 +2617,7 @@ check_for_dispersion <- function(family) {
 #   longitudinal submodel that are to be used in the shared_coef association structure
 # @return Integer indicating the number of association parameters in the model 
 get_num_assoc_pars <- function(has_assoc, which_b_zindex, which_coef_zindex) {
-  sel <- c("etavalue", "etaslope", "muvalue", "muslope")
+  sel <- c("etavalue", "etaslope", "etalag", "etaauc", "muvalue", "muslope", "mulag", "muauc")
   a_K <- sum(unlist(has_assoc[sel]))
   a_K <- a_K + length(unlist(which_b_zindex)) + length(unlist(which_coef_zindex))
   return(a_K)
@@ -2411,7 +2687,7 @@ priorLong_options <- function(prior_scale_for_dispersion = 5,
 #'   hazard within each interval, which are given normal distributions
 #'   with location 0.
 #'  
-priorEvent_options <- function(prior_scale_for_basehaz = 5,
+priorEvent_options <- function(prior_scale_for_basehaz = 50,
                                min_prior_scale = 1e-12, 
                                scaled = TRUE) {
   validate_parameter_value(prior_scale_for_basehaz)

--- a/exec/jm.stan
+++ b/exec/jm.stan
@@ -442,30 +442,28 @@ functions {
   /** 
   * Reorder the vector of group-specific coefficients
   *
-  * @param b Vector whose elements are ordered in terms of group-specific 
-  *   parameter within factor level within grouping factor
+  * @param b Vector whose elements are ordered in the following nested way:
+  *   factor level (e.g. "subject ID" or "clinic ID") within grouping 
+  *   factor (e.g. "subjects" or "clinics")
   * @param p An integer array with the number variables on the LHS of each |
   * @param pmat A matrix with the number variables on the LHS of each | in each
   *   longitudinal submodel. The rows correspond to each |, meaning the separate
-  *   equations for each grouping factor, whilst the columns correspond to each
-  *   longitudinal submodel. If subject ID is the only grouping factor then the
+  *   equations for each grouping variable, and the columns correspond to each
+  *   longitudinal submodel. If subject ID is the only grouping variable then the
   *   matrix will have one row. If the joint model only has one longitudinal 
   *   submodel then the matrix will have one column.
-  * @param q1 An integer array with the number of group-specific coefficients 
-  *   for each grouping factor.
-  * @param q1 An integer array with the number of group-specific coefficients 
-  *   for each longitudinal submodel.  
-  * @param qmat A matrix with the number of group-specific coefficients for the 
-  *   LHS of each |. The rows correspond to each |, meaning the separate equations  
-  *   for each grouping factor, and the columns correspond to each longitudinal
+  * @param p An integer array with the number of random coefficients for the 
+  *   LHS of each |
+  * @param qmat A matrix with the number of random coefficients for the LHS of each | 
+  *   The rows correspond to each |, meaning the separate equations for 
+  *   each grouping variable, and the columns correspond to each longitudinal
   *   submodel.
   * @param l An integer array with the number of levels for the factor(s) on 
   *   the RHS of each |
   * @param M An integer specifying the number of longitudinal submodels
-  * @return A vector of group-specific coefficients whose elements are 
-  *   ordered in terms of group-specific parameter within factor level within
-  *   grouping factor within longitudinal submodel (i.e. ordered by longitudinal
-  *   submodel).
+  * @return A vector (containing the group-specific coefficients) whose whose 
+  *   elements are ordered in the following nested way: factor level, within
+  *   grouping factor, within longitudinal submodel
   */ 
   vector reorder_b(vector b, int[] p, int[,] pmat, int[] q1, int[] q2, 
                    int[,] qmat, int[] l, int M) {
@@ -543,29 +541,29 @@ functions {
   * @param p An integer array with the number of variables on the LHS of each |
   * @param pmat A matrix with the number variables on the LHS of each | in each
   *   longitudinal submodel. The rows correspond to each |, meaning the separate
-  *   equations for each grouping factor, and the columns correspond to each
+  *   equations for each grouping variable, and the columns correspond to each
   *   longitudinal submodel. If subject ID is the only grouping variable then the
   *   matrix will have one row. If the joint model only has one longitudinal 
   *   submodel then the matrix will have one column.
   * @param Npat Integer specifying number of individuals represented 
-  *   in vector b (not the same as l, since padded _NEW_ is not counted).
-  * @param quadnodes The number of Gauss-Kronrod quadrature nodes
+  *   in vector b
+  * @param quadnodes The number of quadrature nodes
   * @param which_b Integer array specifying the indices
   *   of the random effects to use in the association structure
   * @param sum_size_which_b Integer specifying total number of 
   *   random effects that are to be used in the association structure
-  * @param size_which_b Integer array specifying how many random effects from
-  *   each long submodel are going to be used in forming the association structure
+  * @param size_which_b Integer array specifying number of random effects from
+  *   each long submodel that are to be used in the association structure
   * @param t_i Integer specifying the index of the grouping factor that
-  *   corresponds to the subject / individual
+  *   corresponds to the patient-level
   * @param M An integer specifying the number of longitudinal submodels
   * @return A matrix with the desired random effects represented
   *   in columns, and the individuals on the rows; the matrix is
   *   repeated (quadnodes + 1) times (bounded by rows)
   */  
-  matrix make_x_assoc_shared_b(vector b, int[] l, int[] p, int[,] pmat, int Npat, 
-                               int quadnodes, int[] which_b, int sum_size_which_b, 
-							   int[] size_which_b, int t_i, int M) {
+  matrix make_x_assoc_shared_b(
+    vector b, int[] l, int[] p, int[,] pmat, int Npat, int quadnodes,
+    int[] which_b, int sum_size_which_b, int[] size_which_b, int t_i, int M) {
     int prior_shift;    // num. ranefs prior to subject-specific ranefs
     int start_store;
     int end_store;	
@@ -612,41 +610,27 @@ functions {
   * structure in the joint model
   *
   * @param b Vector of group-specific coefficients
-  * @param y_beta Vector of fixed effect regression coefficients for all 
-  *   longitudinal submodels
-  * @param y_K Integer array with the number of fixed effect regression
-  *   coefficients in each longitudinal submodel
-  * @param M An integer specifying the number of longitudinal submodels
-  * @param t_i Integer specifying the index of the grouping factor that
-  *   corresponds to the subject / individual
   * @param l An integer array with the number of levels for the factor(s) on 
   *   the RHS of each |
   * @param p An integer array with the number of variables on the LHS of each |
   * @param pmat A matrix with the number variables on the LHS of each | in each
   *   longitudinal submodel. The rows correspond to each |, meaning the separate
-  *   equations for each grouping factor, and the columns correspond to each
-  *   longitudinal submodel. If subject ID is the only grouping factor then the
+  *   equations for each grouping variable, and the columns correspond to each
+  *   longitudinal submodel. If subject ID is the only grouping variable then the
   *   matrix will have one row. If the joint model only has one longitudinal 
   *   submodel then the matrix will have one column.
   * @param Npat Integer specifying number of individuals represented 
-  *   in vector b (not the same as l, since padded _NEW_ is not counted).
-  * @param quadnodes The number of Gauss-Kronrod quadrature nodes
-  * @param sum_size_which_coef Integer specifying total number of 
+  *   in vector b
+  * @param quadnodes The number of quadrature nodes
+  * @param which_b Integer array specifying the indices
+  *   of the random effects to use in the association structure
+  * @param sum_size_which_b Integer specifying total number of 
   *   random effects that are to be used in the association structure
-  * @param size_which_coef Integer array specifying how many random effects from
-  *   each long submodel that are to be used in forming the association structure
-  * @param which_coef_zindex Integer array specifying the indices of the
-  *   random effects that should be used in forming the association structure
-  * @param which_coef_xindex Integer array specifying the indices
-  *   of the corresponding fixed effects that should be used in forming the 
-  *   association structure  
-  * @param y_has_intercept An integer array with indicators for whether
-  *   each longitudinal submodel has an intercept
-  * @param y_has_intercept_ Integer arrays for whether each longitudinal 
-  *   submodel has a specific type of interceot.  
-  * @param y_gamma_unbound,y_gamma_lobound,y_gamma_upbound Real arrays
-  *   containing the unbounded, lower bounded (at zero), or upper bounded
-  *   (at zero) estimated intercepts
+  * @param size_which_b Integer array specifying number of random effects from
+  *   each long submodel that are to be used in the association structure
+  * @param t_i Integer specifying the index of the grouping factor that
+  *   corresponds to the patient-level
+  * @param M An integer specifying the number of longitudinal submodels
   * @return A matrix with the desired random effects represented
   *   in columns, and the individuals on the rows; the matrix is
   *   repeated (quadnodes + 1) times (bounded by rows)
@@ -744,90 +728,108 @@ functions {
 data {
   
   // dimensions
-  int<lower=1> M;                      // num. of long. submodels
-  int<lower=0> Npat;                   // num. individuals (equal to l[1] - 1)
-  int<lower=0> y_N[M];                 // num. of obs. in each long. submodel
-  int<lower=0> sum_y_N;                // total num. of obs. across all long submodels
-  int<lower=0> sum_y_real_N;           // total num. of obs. across all long submodels with real outcomes
-  int<lower=0> sum_y_int_N;            // total num. of obs. across all long submodels with integer outcomes
+  int<lower=1> M;  // num. of long. submodels
+  int<lower=0> Npat;  // num. individuals (equal to l[1] - 1)
+  int<lower=0> y_N[M];  // num. of obs. in each long. submodel
+  int<lower=0> sum_y_N; // total num. of obs. across all long submodels
+  int<lower=0> sum_y_real_N; // total num. of obs. across all long submodels with real outcomes
+  int<lower=0> sum_y_int_N; // total num. of obs. across all long submodels with integer outcomes
   int<lower=0,upper=sum_y_N> y_beg[M]; // index of first obs. for each submodel
   int<lower=0,upper=sum_y_N> y_end[M]; // index of last obs. for each submodel
   int<lower=0,upper=sum_y_real_N> y_real_beg[M]; // index of first obs. for each submodel
   int<lower=0,upper=sum_y_real_N> y_real_end[M]; // index of last obs. for each submodel
-  int<lower=0,upper=sum_y_int_N> y_int_beg[M];   // index of first obs. for each submodel
-  int<lower=0,upper=sum_y_int_N> y_int_end[M];   // index of last obs. for each submodel
-  int<lower=0> y_N01[M,2];             // num. of bernoulli 0/1 observations in each long. submodel
-  int<lower=0> y_K[M];                 // num. of predictors in each long. submodel
-  int<lower=0> sum_y_K;                // total num. of predictors across all long submodels
-  int<lower=0> e_K;                    // num. of predictors in event submodel
-  int<lower=0> a_K;                    // num. of association parameters
-  int<lower=0> quadnodes;              // num. of nodes for Gauss-Kronrod quadrature 
+  int<lower=0,upper=sum_y_int_N> y_int_beg[M]; // index of first obs. for each submodel
+  int<lower=0,upper=sum_y_int_N> y_int_end[M]; // index of last obs. for each submodel
+  int<lower=0> y_N01[M,2];  // num. of bernoulli 0/1 observations in each long. submodel
+  int<lower=0> y_K[M];  // num. of predictors in each long. submodel
+  int<lower=0> sum_y_K; // total num. of predictors across all long submodels
+  int<lower=0> e_K;   // num. of predictors in event submodel
+  int<lower=0> a_K;   // num. of association parameters
+  int<lower=0> quadnodes;  // num. of nodes for Gauss-Kronrod quadrature 
   int<lower=0> Npat_times_quadnodes;
-  int<lower=0,upper=M> sum_y_has_intercept;         // num. submodels w/ intercept
+  int<lower=0,upper=M> sum_y_has_intercept; // num. submodels w/ intercept
   int<lower=0,upper=M> sum_y_has_intercept_unbound; // num. submodels w/ unbounded intercept
   int<lower=0,upper=M> sum_y_has_intercept_lobound; // num. submodels w/ lower bounded intercept
   int<lower=0,upper=M> sum_y_has_intercept_upbound; // num. submodels w/ upper bounded intercept
-  int<lower=0,upper=M> sum_y_has_dispersion;        // num. submodels w/ dispersion term
+  int<lower=0,upper=M> sum_y_has_dispersion; // num. submodels w/ dispersion term
   
   // data for longitudinal submodel(s)
-  int<lower=1> family[M];                   // family (1=gaus,2=gam,3=ig,4=bern,5=bin,6=pois,7=nb,8=pois-gam)
-  int<lower=0,upper=1> any_fam_3;           // any long. submodel with family == 3
-  int<lower=1> link[M];                     // link function, varies by family
-  int<lower=0,upper=1> y_centre;            // 1 = yes for centred predictor matrix
+  int<lower=1> family[M];          // family
+  int<lower=0,upper=1> any_fam_3;  // any long. submodel with family == 3
+  int<lower=1> link[M];            // link function, varies by .stan file
+  int<lower=0,upper=1> y_centre;         // 1 = yes for centred predictor matrix
   int<lower=0,upper=1> y_has_intercept[M];  // 1 = yes
   int<lower=0,upper=1> y_has_intercept_unbound[M];  // intercept unbounded
   int<lower=0,upper=1> y_has_intercept_lobound[M];  // intercept lower bound at 0
   int<lower=0,upper=1> y_has_intercept_upbound[M];  // intercept upper bound at 0
-  int<lower=0,upper=1> has_weights;         // 1 = Yes
-  //int<lower=0,upper=1> y_has_offset;      // 1 = Yes
-  int<lower=0,upper=1> y_has_dispersion[M]; // 1 = Yes
-  vector[sum_y_real_N] y_real;              // outcome vector, reals                
-  int<lower=0> y_int[sum_y_int_N];          // outcome vector, integers                
-  vector[sum_y_K*(y_centre>0)] y_xbar;      // predictor means
-  matrix[sum_y_N,sum_y_K] y_X;              // predictor matrix, possibly centred          
-  vector[sum_y_N] y_weights;                // weights, set to zero if not used
-  int<lower=0> trials[sum_y_N];             // num. binomial trials, set to zero if not used
+  int<lower=0,upper=1> has_weights;    // 1 = Yes
+  //int<lower=0,upper=1> y_has_offset;     // 1 = Yes
+  int<lower=0,upper=1> y_has_dispersion[M];    // 1 = Yes
+  vector[sum_y_real_N] y_real;           // outcome vector, reals                
+  int<lower=0> y_int[sum_y_int_N];        // outcome vector, integers                
+  vector[sum_y_K*(y_centre>0)] y_xbar;  // predictor means
+  matrix[sum_y_N,sum_y_K] y_X;   // predictor matrix, possibly centred          
+  vector[sum_y_N] y_weights;  // weights, set to zero if not used
+  int<lower=0> trials[sum_y_N];  // num. binomial trials, set to zero if not used
   //vector[sum_y_N*y_has_offset] y_offset; 
-  int<lower=0> num_non_zero;                // number of non-zero elements in the Z matrix
-  vector[num_non_zero] w;                   // non-zero elements in the implicit Z matrix
-  int<lower=0> v[num_non_zero];             // column indices for w  
-  int<lower=0> u[(sum_y_N+1)];              // where the non-zeros start in each row 
+  int<lower=0> num_non_zero;   // number of non-zero elements in the Z matrix
+  vector[num_non_zero] w;  // non-zero elements in the implicit Z matrix
+  int<lower=0> v[num_non_zero]; // column indices for w  
+  int<lower=0> u[(sum_y_N+1)];  // where the non-zeros start in each row 
   
   // data for event submodel
-  int<lower=0,upper=1> basehaz_weibull;     // weibull baseline hazard
-  int<lower=0,upper=1> basehaz_piecewise;   // piecewise constant baseline hazard
-  int<lower=0,upper=1> basehaz_bs;          // B-splines baseline hazard
-  int<lower=0> bs_df;                       // df for B-splines baseline hazard
-  int<lower=0> piecewise_df;                // number of segments for piecewise constant baseline hazard
-  int<lower=0,upper=1> e_centre;            // 1 = yes for centred predictor matrix
-  int<lower=0,upper=1> e_has_intercept;     // 1 = yes
-  int<lower=0> nrow_y_Xq;                   // num. rows in long. predictor matrix at quad points
-  int<lower=0> nrow_e_Xq;                   // num. rows in event predictor matrix at quad points
-  matrix[(M*nrow_y_Xq),sum_y_K] y_Xq;       // predictor matrix (long submodel) at quadpoints, possibly centred              
-  matrix[nrow_e_Xq,e_K] e_Xq;               // predictor matrix (event submodel) at quadpoints, possibly centred
-  vector[nrow_e_Xq] e_times;                // event times and unstandardised quadrature points
+  int<lower=0,upper=1> basehaz_weibull;  // weibull baseline hazard
+  int<lower=0,upper=1> basehaz_piecewise;  // piecewise constant baseline hazard
+  int<lower=0,upper=1> basehaz_bs;  // B-splines baseline hazard
+  int<lower=0> bs_df;  // df for B-splines baseline hazard
+  int<lower=0> piecewise_df;  // number of segments for piecewise constant baseline hazard
+  int<lower=0,upper=1> e_centre;  // 1 = yes for centred predictor matrix
+  int<lower=0,upper=1> e_has_intercept;  // 1 = yes
+  int<lower=0> nrow_y_Xq;     // num. rows in long. predictor matrix at quad points
+  int<lower=0> nrow_e_Xq;   // num. rows in event predictor matrix at quad points
+  matrix[(M*nrow_y_Xq),sum_y_K] y_Xq; // predictor matrix (long submodel) at quadpoints, possibly centred              
+  matrix[nrow_e_Xq,e_K] e_Xq;         // predictor matrix (event submodel) at quadpoints, possibly centred
+  vector[nrow_e_Xq] e_times;          // event times and unstandardised quadrature points
   matrix[(nrow_e_Xq*basehaz_bs),bs_df] e_ns_times; // basis for B-splines baseline hazard
   matrix[(nrow_e_Xq*basehaz_piecewise),piecewise_df] e_times_piecedummy; // dummy indicators for piecewise constant baseline hazard
-  vector[nrow_e_Xq] e_d;                    // event indicator, followed by dummy indicator for quadpoints
-  vector[e_K*(e_centre>0)] e_xbar;          // predictor means (event submodel)
-  int<lower=0> num_non_zero_Zq;             // number of non-zero elements in the Z matrix (at quadpoints)
-  vector[num_non_zero_Zq] w_Zq;             // non-zero elements in the implicit Z matrix (at quadpoints)
-  int<lower=0> v_Zq[num_non_zero_Zq];       // column indices for w (at quadpoints)
-  int<lower=0> u_Zq[(M*nrow_y_Xq+1)];       // where the non-zeros start in each row (at quadpoints)
-  vector[Npat] e_weights;                   // weights, set to zero if not used
-  vector[Npat_times_quadnodes] e_weights_rep; // repeated weights, set to zero if not used
-  vector[Npat_times_quadnodes] quadweight_times_half_eventtime;
+  vector[nrow_e_Xq] e_d;              // event indicator, followed by dummy indicator for quadpoints
+  vector[e_K*(e_centre>0)] e_xbar;   // predictor means (event submodel)
+  int<lower=0> num_non_zero_Zq;    // number of non-zero elements in the Z matrix (at quadpoints)
+  vector[num_non_zero_Zq] w_Zq;  // non-zero elements in the implicit Z matrix (at quadpoints)
+  int<lower=0> v_Zq[num_non_zero_Zq]; // column indices for w (at quadpoints)
+  int<lower=0> u_Zq[(M*nrow_y_Xq+1)]; // where the non-zeros start in each row (at quadpoints)
+  vector[Npat] e_weights;           // weights, set to zero if not used
+  vector[Npat_times_quadnodes] e_weights_rep;   // repeated weights, set to zero if not used
+  vector[Npat_times_quadnodes] quadweight;
     
   // data for association structure
   int<lower=0,upper=1> assoc;              // 0 = no jm association structure, 1 = any jm association structure
   int<lower=0,upper=1> has_assoc_ev[M];    // eta value
   int<lower=0,upper=1> has_assoc_es[M];    // eta slope
-  int<lower=0,upper=1> has_assoc_cv[M];    // mu value
-  int<lower=0,upper=1> has_assoc_cs[M];    // mu slope
+  int<lower=0,upper=1> has_assoc_el[M];    // eta lag
+  int<lower=0,upper=1> has_assoc_ea[M];    // eta auc
+  int<lower=0,upper=1> has_assoc_mv[M];    // mu value
+  int<lower=0,upper=1> has_assoc_ms[M];    // mu slope
+  int<lower=0,upper=1> has_assoc_ml[M];    // mu lag
+  int<lower=0,upper=1> has_assoc_ma[M];    // mu auc
+  int<lower=0,upper=1> has_assoc_evi[M];   // eta value interacted with data
+  int<lower=0,upper=1> has_assoc_esi[M];   // eta slope interacted with data
+  int<lower=0,upper=1> has_assoc_mvi[M];   // mu value interacted with data
+  int<lower=0,upper=1> has_assoc_msi[M];   // mu slope interacted with data 
   int<lower=0,upper=M> sum_has_assoc_ev;   // num. long submodels linked via eta value
   int<lower=0,upper=M> sum_has_assoc_es;   // num. long submodels linked via eta slope
-  int<lower=0,upper=M> sum_has_assoc_cv;   // num. long submodels linked via mu value
-  int<lower=0,upper=M> sum_has_assoc_cs;   // num. long submodels linked via mu slope 
+  int<lower=0,upper=M> sum_has_assoc_el;   // num. long submodels linked via eta lag
+  int<lower=0,upper=M> sum_has_assoc_ea;   // num. long submodels linked via eta auc
+  int<lower=0,upper=M> sum_has_assoc_mv;   // num. long submodels linked via mu value
+  int<lower=0,upper=M> sum_has_assoc_ms;   // num. long submodels linked via mu slope 
+  int<lower=0,upper=M> sum_has_assoc_ml;   // num. long submodels linked via mu lag
+  int<lower=0,upper=M> sum_has_assoc_ma;   // num. long submodels linked via mu auc
+  int<lower=0,upper=M> sum_has_assoc_evi;  // num. long submodels linked via eta value interacted with data
+  int<lower=0,upper=M> sum_has_assoc_esi;  // num. long submodels linked via eta slope interacted with data
+  int<lower=0,upper=M> sum_has_assoc_mvi;  // num. long submodels linked via mu value interacted with data
+  int<lower=0,upper=M> sum_has_assoc_msi;  // num. long submodels linked via mu slope interacted with data 
+  int<lower=0,upper=a_K> sum_a_K_int;      // num. of parameters devoted to interaction terms in association structure
+  int<lower=0,upper=sum_a_K_int> a_K_int[4*M]; // num. of parameters devoted to interaction terms in association structure, by submodel and by ev/es/mv/ms interactions
   int<lower=0> sum_size_which_b;           // num. of shared random effects
   int<lower=0> size_which_b[M];            // num. of shared random effects for each long submodel
   int<lower=1> which_b_zindex[sum_size_which_b];  // which random effects are shared for each long submodel
@@ -836,15 +838,39 @@ data {
   int<lower=1> which_coef_zindex[sum_size_which_coef];  // which random effects are shared incl fixed component for each long submodel
   int<lower=1> which_coef_xindex[sum_size_which_coef];  // which fixed effects are shared
 
-  // data for calculating slope of the longitudinal submodel
+  // data for calculating slope
   real<lower=0> eps;  // time shift used for numerically calculating derivative
-  matrix[(M*nrow_y_Xq*((sum_has_assoc_es + sum_has_assoc_cs) > 0)),sum_y_K] 
-    y_Xq_eps;  // predictor matrix (long submodel) at quadpoints plus time shift of epsilon              
-  int<lower=0> num_non_zero_Zq_eps;  // number of non-zero elements in the Zq_eps matrix (at quadpoints plus time shift of epsilon)
-  vector[num_non_zero_Zq_eps] w_Zq_eps;  // non-zero elements in the implicit Zq_eps matrix (at quadpoints plus time shift of epsilon)
-  int<lower=0> v_Zq_eps[num_non_zero_Zq_eps];  // column indices for w (at quadpoints plus time shift of epsilon)
-  int<lower=0> u_Zq_eps[(M*nrow_y_Xq*((sum_has_assoc_es + sum_has_assoc_cs) > 0) + 1)]; 
+  matrix[(M*nrow_y_Xq*((sum_has_assoc_es + sum_has_assoc_ms) > 0)),sum_y_K] 
+    y_Xq_eps; // predictor matrix (long submodel) at quadpoints plus time shift of epsilon              
+  int<lower=0> num_non_zero_Zq_eps;        // number of non-zero elements in the Zq_eps matrix (at quadpoints plus time shift of epsilon)
+  vector[num_non_zero_Zq_eps] w_Zq_eps;    // non-zero elements in the implicit Zq_eps matrix (at quadpoints plus time shift of epsilon)
+  int<lower=0> v_Zq_eps[num_non_zero_Zq_eps]; // column indices for w (at quadpoints plus time shift of epsilon)
+  int<lower=0> u_Zq_eps[(M*nrow_y_Xq*((sum_has_assoc_es + sum_has_assoc_ms) > 0) + 1)]; 
     // where the non-zeros start in each row (at quadpoints plus time shift of epsilon)
+
+  // data for calculating lag
+  matrix[(M*nrow_y_Xq*((sum_has_assoc_el + sum_has_assoc_ml) > 0)),sum_y_K] 
+    y_Xq_lag; // predictor matrix (long submodel) at lagged quadpoints            
+  int<lower=0> num_non_zero_Zq_lag;        // number of non-zero elements in the Zq_lag matrix (at lagged quadpoints)
+  vector[num_non_zero_Zq_lag] w_Zq_lag;    // non-zero elements in the implicit Zq_lag matrix (at lagged quadpointsn)
+  int<lower=0> v_Zq_lag[num_non_zero_Zq_lag]; // column indices for w (at lagged quadpoints)
+  int<lower=0> u_Zq_lag[(M*nrow_y_Xq*((sum_has_assoc_el + sum_has_assoc_ml) > 0) + 1)]; 
+    // where the non-zeros start in each row (at lagged quadpoints)
+
+  // data for calculating auc
+  int<lower=0> nrow_y_Xq_auc;     // num. rows in long. predictor matrix at auc quad points
+  int<lower=0> auc_quadnodes;              // num. of nodes for Gauss-Kronrod quadrature for area under marker trajectory 
+  vector[nrow_y_Xq_auc] auc_quadweight;
+  matrix[(M*nrow_y_Xq_auc*((sum_has_assoc_ea + sum_has_assoc_ma) > 0)),sum_y_K] 
+    y_Xq_auc; // predictor matrix (long submodel) at auc quadpoints            
+  int<lower=0> num_non_zero_Zq_auc;        // number of non-zero elements in the Zq_lag matrix (at auc quadpoints)
+  vector[num_non_zero_Zq_auc] w_Zq_auc;    // non-zero elements in the implicit Zq_lag matrix (at auc quadpointsn)
+  int<lower=0> v_Zq_auc[num_non_zero_Zq_auc]; // column indices for w (at auc quadpoints)
+  int<lower=0> u_Zq_auc[(M*nrow_y_Xq_auc*((sum_has_assoc_ea + sum_has_assoc_ma) > 0) + 1)]; 
+    // where the non-zeros start in each row (at auc quadpoints)
+
+  // data for calculating interactions in association structure
+  vector[nrow_e_Xq] y_Xq_int[sum_a_K_int]; // design matrix for interacting with ev/es/mv/ms at quadpoints            
 
   // data for random effects model
   int<lower=1> t;     	        // num. of grouping factors
@@ -1025,6 +1051,7 @@ parameters {
   real y_gamma_unbound[sum_y_has_intercept_unbound];
   real<lower=0> y_gamma_lobound[sum_y_has_intercept_lobound];  
   real<upper=0> y_gamma_upbound[sum_y_has_intercept_upbound];  
+
   vector[sum_y_K] y_z_beta;                // primative coefs (long submodels)
   vector<lower=0>[sum_y_has_dispersion] y_dispersion_unscaled; # interpretation depends on family!
   #vector<lower=0>[sum_y_noise_N] y_noise; // do not store this
@@ -1033,7 +1060,7 @@ parameters {
   real e_gamma[e_has_intercept];          // intercept (event model)
   vector[e_K] e_z_beta;                   // primative coefs (event submodel)
   real<lower=0> weibull_shape_unscaled[basehaz_weibull];  // unscaled weibull shape parameter 
-  vector[bs_df] bs_coefs_unscaled;        // unscaled coefs for B-splines on the log baseline hazard scale
+  vector[bs_df] bs_coefs_unscaled;       // unscaled coefs for cubic bs on log baseline hazard
   vector[piecewise_df] piecewise_coefs_unscaled;  // unscaled coefs for piecewise constant baseline hazard
  
   // parameters for association structure
@@ -1068,17 +1095,21 @@ transformed parameters {
   
   // parameters for GK quadrature  
   vector[(M*nrow_y_Xq)] y_eta_q;          // linear predictor (all long submodels) evaluated at quadpoints
-  vector[(M*nrow_y_Xq)*((sum_has_assoc_es + sum_has_assoc_cs) > 0)] y_eta_q_eps; 
+  vector[(M*nrow_y_Xq)*((sum_has_assoc_es + sum_has_assoc_ms) > 0)] y_eta_q_eps; 
     // linear predictor (all long submodels) evaluated at quadpoints plus time shift of epsilon
+  vector[(M*nrow_y_Xq)*((sum_has_assoc_el + sum_has_assoc_ml) > 0)] y_eta_q_lag; 
+    // linear predictor (all long submodels) evaluated at lagged quadpoints
+  vector[(M*nrow_y_Xq_auc)*((sum_has_assoc_ea + sum_has_assoc_ma) > 0)] y_eta_q_auc; 
+    // linear predictor (all long submodels) evaluated at lagged quadpoints
   vector[nrow_e_Xq] e_eta_q;      // linear predictor (event submodel) evaluated at quadpoints
-  vector[nrow_e_Xq] log_basehaz;  // baseline hazard evaluated at quadpoints
+  vector[nrow_e_Xq] log_basehaz;      // baseline hazard evaluated at quadpoints
   vector[nrow_e_Xq] ll_haz_q;     // log hazard contribution to the log likelihood for the event model at event time and quad points
   vector[Npat] ll_haz_eventtime;  // log hazard contribution to the log likelihood for the event model AT the event time only
   vector[Npat_times_quadnodes] ll_haz_quadtime;    // log hazard for the event model AT the quadrature points only
   vector[Npat_times_quadnodes] ll_surv_eventtime;  // log survival contribution to the log likelihood for the event model AT the event time
   real sum_ll_haz_eventtime;
   real sum_ll_surv_eventtime;
-  real ll_event;  // log likelihood for the event model    
+  real ll_event;                                   // log likelihood for the event model    
   
   // parameters for association structure  
   vector[a_K] a_beta;           
@@ -1198,7 +1229,7 @@ transformed parameters {
     theta_L = make_theta_L(len_theta_L, p, 1.0, tau, scale, zeta, rho, z_T);
     b = make_b(z_b, theta_L, p, l);
     if (M > 1) b_by_model = reorder_b(b, p, pmat, q1, q2, qmat, l, M);
-	else b_by_model = b;
+	  else b_by_model = b;
   }
   
   //===============
@@ -1208,16 +1239,33 @@ transformed parameters {
   // Longitudinal submodel(s): linear predictor at event and quad times
   if (sum_y_K > 0) y_eta_q = y_Xq * y_beta;
   else y_eta_q = rep_vector(0.0, (M*nrow_y_Xq));
-  //if (y_has_offset == 1) y_eta_q = y_eta_q + y_offset;
+  //if (y_has_offset == 1) y_eta_q = y_eta_q + y_offset; # how to handle offset?
   y_eta_q = y_eta_q + csr_matrix_times_vector((M*nrow_y_Xq), len_b, w_Zq, v_Zq, u_Zq, b_by_model);
 
   // Longitudinal submodel(s): slope of linear predictor at event and quad times
-  if ((sum_has_assoc_es > 0) || (sum_has_assoc_cs > 0)) {
+  if ((sum_has_assoc_es > 0) || (sum_has_assoc_ms > 0)) {
     if (sum_y_K > 0) y_eta_q_eps = y_Xq_eps * y_beta;
     else y_eta_q_eps = rep_vector(0.0, (M*nrow_y_Xq));
-    //if (y_has_offset == 1) y_eta_q_eps = y_eta_q_eps + y_offset; # how to handle offset in derivative?
+    //if (y_has_offset == 1) y_eta_q_eps = y_eta_q_eps + y_offset; # how to handle offset?
     y_eta_q_eps = y_eta_q_eps + csr_matrix_times_vector((M*nrow_y_Xq), len_b, w_Zq_eps, v_Zq_eps, u_Zq_eps, b_by_model);
   }
+
+  // Longitudinal submodel(s): lagged value of linear predictor at event and quad times
+  if ((sum_has_assoc_el > 0) || (sum_has_assoc_ml > 0)) {
+    if (sum_y_K > 0) y_eta_q_lag = y_Xq_lag * y_beta;
+    else y_eta_q_lag = rep_vector(0.0, (M*nrow_y_Xq));
+    //if (y_has_offset == 1) y_eta_q_lag = y_eta_q_lag + y_offset; # how to handle offset?
+    y_eta_q_lag = y_eta_q_lag + csr_matrix_times_vector((M*nrow_y_Xq), len_b, w_Zq_lag, v_Zq_lag, u_Zq_lag, b_by_model);
+  }  
+  
+  // Longitudinal submodel(s): linear predictor at marker auc quadtimes
+  if ((sum_has_assoc_ea > 0) || (sum_has_assoc_ma > 0)) {
+    if (sum_y_K > 0) y_eta_q_auc = y_Xq_auc * y_beta;
+    else y_eta_q_auc = rep_vector(0.0, (M*nrow_y_Xq_auc));
+    //if (y_has_offset == 1) y_eta_q_auc = y_eta_q_auc + y_offset; # how to handle offset?
+    y_eta_q_auc = y_eta_q_auc + csr_matrix_times_vector((M*nrow_y_Xq_auc), len_b, w_Zq_auc, v_Zq_auc, u_Zq_auc, b_by_model);
+  }   
+  
   // Event submodel: linear predictor at event and quad times
   if (e_K > 0) e_eta_q = e_Xq * e_beta;
   else e_eta_q = rep_vector(0.0, nrow_e_Xq);
@@ -1231,12 +1279,18 @@ transformed parameters {
 
   if (assoc == 1) {
     int mark;
+  	int mark2;  // tracks index within a_K_int vector, which is vector specifying the number of columns used for each possible interaction-based association structure
 	  mark = 0;
+	  mark2 = 0;
     for (m in 1:M) {
-      vector[nrow_y_Xq] ysep_eta_q;     // linear predictor for a single long. submodel at event and quad times
-      vector[nrow_y_Xq] ysep_q;         // mu for a single long. submodel at event and quad times
-      vector[nrow_y_Xq] ysep_eta_q_eps; // linear predictor for a single long. submodel at event and quad times, following time shift of epsilon
-      vector[nrow_y_Xq] ysep_q_eps;     // mu for a single long. submodel at event and quad times, following time shift of epsilon
+      vector[nrow_y_Xq] ysep_eta_q;     // linear predictor (each long submodel) evaluated at quadpoints
+      vector[nrow_y_Xq] ysep_q;         // expected long. outcome at event and quad times   
+      vector[nrow_y_Xq] ysep_eta_q_eps;  
+      vector[nrow_y_Xq] ysep_q_eps;     
+      vector[nrow_y_Xq] ysep_eta_q_lag;  
+      vector[nrow_y_Xq] ysep_q_lag;     
+      vector[nrow_y_Xq_auc] ysep_eta_q_auc;  
+      vector[nrow_y_Xq_auc] ysep_q_auc;  
       
       # Prep work for association structures
       
@@ -1249,7 +1303,7 @@ transformed parameters {
         else if (y_has_intercept_lobound[m] == 1)
           ysep_eta_q = ysep_eta_q - min(ysep_eta_q) + 
                              y_gamma_lobound[sum(y_has_intercept_lobound[1:m])];
-  	    else if (y_has_intercept_upbound[m] == 1)
+  	  else if (y_has_intercept_upbound[m] == 1)
           ysep_eta_q = ysep_eta_q - max(ysep_eta_q) + 
                              y_gamma_upbound[sum(y_has_intercept_upbound[1:m])];
       }
@@ -1265,7 +1319,7 @@ transformed parameters {
       }
       
       # Linear predictor at time plus epsilon
-      if ((has_assoc_es[m] == 1) || (has_assoc_cs[m] == 1)) {
+      if ((has_assoc_es[m] == 1) || (has_assoc_esi[m] == 1) || (has_assoc_ms[m] == 1) || (has_assoc_msi[m] == 1)) {
         ysep_eta_q_eps = segment(y_eta_q_eps, ((m-1) * nrow_y_Xq) + 1, nrow_y_Xq);
         if (y_has_intercept[m] == 1) {
           if (y_has_intercept_unbound[m] == 1) 
@@ -1274,7 +1328,7 @@ transformed parameters {
           else if (y_has_intercept_lobound[m] == 1)
             ysep_eta_q_eps = ysep_eta_q_eps - min(ysep_eta_q_eps) + 
                                y_gamma_lobound[sum(y_has_intercept_lobound[1:m])];
-    	  else if (y_has_intercept_upbound[m] == 1)
+    	    else if (y_has_intercept_upbound[m] == 1)
             ysep_eta_q_eps = ysep_eta_q_eps - max(ysep_eta_q_eps) + 
                                y_gamma_upbound[sum(y_has_intercept_upbound[1:m])];
         }
@@ -1289,9 +1343,61 @@ transformed parameters {
                 dot_product(y_xbar[mark_beg:mark_end], y_beta[mark_beg:mark_end]); 
         }
       } 
+
+      # Linear predictor at lagged time
+      if ((has_assoc_el[m] == 1) || (has_assoc_ml[m] == 1)) {
+        ysep_eta_q_lag = segment(y_eta_q_lag, ((m-1) * nrow_y_Xq) + 1, nrow_y_Xq);
+        if (y_has_intercept[m] == 1) {
+          if (y_has_intercept_unbound[m] == 1) 
+            ysep_eta_q_lag = ysep_eta_q_lag +
+                               y_gamma_unbound[sum(y_has_intercept_unbound[1:m])];
+          else if (y_has_intercept_lobound[m] == 1)
+            ysep_eta_q_lag = ysep_eta_q_lag - min(ysep_eta_q_lag) + 
+                               y_gamma_lobound[sum(y_has_intercept_lobound[1:m])];
+    	    else if (y_has_intercept_upbound[m] == 1)
+            ysep_eta_q_lag = ysep_eta_q_lag - max(ysep_eta_q_lag) + 
+                               y_gamma_upbound[sum(y_has_intercept_upbound[1:m])];
+        }
+        else if (y_centre == 1) {
+          int mark_beg;
+          int mark_end;
+          if (m == 1) mark_beg = 1;
+          else mark_beg = sum(y_K[1:(m-1)]) + 1;
+          mark_end = sum(y_K[1:m]);   
+          // correction to eta if model has no intercept (and X is centered)
+          ysep_eta_q_lag = ysep_eta_q_lag + 
+                dot_product(y_xbar[mark_beg:mark_end], y_beta[mark_beg:mark_end]); 
+        }
+      } 
+      
+      # Linear predictor at auc quadpoints
+      if ((has_assoc_ea[m] == 1) || (has_assoc_ma[m] == 1)) {
+        ysep_eta_q_auc = segment(y_eta_q_auc, ((m-1) * nrow_y_Xq_auc) + 1, nrow_y_Xq_auc);
+        if (y_has_intercept[m] == 1) {
+          if (y_has_intercept_unbound[m] == 1) 
+            ysep_eta_q_auc = ysep_eta_q_auc +
+                               y_gamma_unbound[sum(y_has_intercept_unbound[1:m])];
+          else if (y_has_intercept_lobound[m] == 1)
+            ysep_eta_q_auc = ysep_eta_q_auc - min(ysep_eta_q_lag) + 
+                               y_gamma_lobound[sum(y_has_intercept_lobound[1:m])];
+    	    else if (y_has_intercept_upbound[m] == 1)
+            ysep_eta_q_auc = ysep_eta_q_auc - max(ysep_eta_q_lag) + 
+                               y_gamma_upbound[sum(y_has_intercept_upbound[1:m])];
+        }
+        else if (y_centre == 1) {
+          int mark_beg;
+          int mark_end;
+          if (m == 1) mark_beg = 1;
+          else mark_beg = sum(y_K[1:(m-1)]) + 1;
+          mark_end = sum(y_K[1:m]);   
+          // correction to eta if model has no intercept (and X is centered)
+          ysep_eta_q_auc = ysep_eta_q_auc + 
+                dot_product(y_xbar[mark_beg:mark_end], y_beta[mark_beg:mark_end]); 
+        }
+      }      
       
       # Expected value 
-      if ((has_assoc_cv[m] == 1) || (has_assoc_cs[m] == 1)) {
+      if ((has_assoc_mv[m] == 1) || (has_assoc_mvi[m] == 1) || (has_assoc_ms[m] == 1) || (has_assoc_msi[m] == 1)) {
         if (family[m] == 1) 
           ysep_q = linkinv_gauss(ysep_eta_q, link[m]);
         else if (family[m] == 2) 
@@ -1305,7 +1411,7 @@ transformed parameters {
       }	      
       
       # Expected value at time plus epsilon
-       if (has_assoc_cs[m] == 1) {
+       if ((has_assoc_ms[m] == 1) || (has_assoc_msi[m] == 1)) {
         if (family[m] == 1) 
           ysep_q_eps = linkinv_gauss(ysep_eta_q_eps, link[m]);
         else if (family[m] == 2) 
@@ -1315,31 +1421,171 @@ transformed parameters {
         else if (family[m] == 4)
           ysep_q_eps = linkinv_bern(ysep_eta_q_eps, link[m]);	
         else if (family[m] == 5)		  
-		  ysep_q_eps = linkinv_binom(ysep_eta_q_eps, link[m]); 
+		      ysep_q_eps = linkinv_binom(ysep_eta_q_eps, link[m]); 
       }	     
 
+      # Expected value at lagged time
+       if (has_assoc_ml[m] == 1) {
+        if (family[m] == 1) 
+          ysep_q_lag = linkinv_gauss(ysep_eta_q_lag, link[m]);
+        else if (family[m] == 2) 
+          ysep_q_lag = linkinv_gamma(ysep_eta_q_lag, link[m]);
+        else if (family[m] == 3)
+          ysep_q_lag = linkinv_inv_gaussian(ysep_eta_q_lag, link[m]);
+        else if (family[m] == 4)
+          ysep_q_lag = linkinv_bern(ysep_eta_q_lag, link[m]);	
+        else if (family[m] == 5)		  
+		      ysep_q_lag = linkinv_binom(ysep_eta_q_lag, link[m]); 
+      }	 
+
+      # Expected value at auc quadpoints
+       if (has_assoc_ma[m] == 1) {
+        if (family[m] == 1) 
+          ysep_q_auc = linkinv_gauss(ysep_eta_q_auc, link[m]);
+        else if (family[m] == 2) 
+          ysep_q_auc = linkinv_gamma(ysep_eta_q_auc, link[m]);
+        else if (family[m] == 3)
+          ysep_q_auc = linkinv_inv_gaussian(ysep_eta_q_auc, link[m]);
+        else if (family[m] == 4)
+          ysep_q_auc = linkinv_bern(ysep_eta_q_auc, link[m]);	
+        else if (family[m] == 5)		  
+		      ysep_q_auc = linkinv_binom(ysep_eta_q_auc, link[m]); 
+      }
+      
+      
       # Evaluate association structures
+      
+      # etavalue and any interactions
+      mark2 = mark2 + 1;
       if (has_assoc_ev[m] == 1) {
         mark = mark + 1;
-	    e_eta_q = e_eta_q + a_beta[mark] * ysep_eta_q;
+	      e_eta_q = e_eta_q + a_beta[mark] * ysep_eta_q;
       }	
-      if (has_assoc_cv[m] == 1) {
-        mark = mark + 1;
-        e_eta_q = e_eta_q + a_beta[mark] * ysep_q; 
-      }	
-      if (has_assoc_es[m] == 1) {
+      if (has_assoc_evi[m] == 1) {
+  	    int tmp;
+  	    int j_shift;
+  	    if (mark2 == 1) j_shift = 0;
+  	    else j_shift = sum(a_K_int[1:(mark2-1)]);
+  	    tmp = a_K_int[mark2];  
+        for (j in 1:tmp) {
+          int sel;
+          sel = j_shift + j;
+          mark = mark + 1;
+          e_eta_q = e_eta_q + (ysep_eta_q .* y_Xq_int[sel]) * a_beta[mark];
+        }
+      }
+      
+      # etaslope and any interactions
+      mark2 = mark2 + 1;
+      if ((has_assoc_es[m] == 1) || (has_assoc_esi[m] == 1)) {
         vector[nrow_y_Xq] dydt_eta_q;
         dydt_eta_q = (ysep_eta_q_eps - ysep_eta_q) / eps;
-        mark = mark + 1;
-        e_eta_q = e_eta_q + a_beta[mark] * dydt_eta_q;          
+        if (has_assoc_es[m] == 1) {
+          mark = mark + 1;
+          e_eta_q = e_eta_q + a_beta[mark] * dydt_eta_q;
+        }
+        if (has_assoc_esi[m] == 1) {
+    	    int tmp;
+    	    int j_shift;
+    	    if (mark2 == 1) j_shift = 0;
+    	    else j_shift = sum(a_K_int[1:(mark2-1)]);
+    	    tmp = a_K_int[mark2];  
+          for (j in 1:tmp) {
+            int sel;
+            sel = j_shift + j;
+            mark = mark + 1;
+            e_eta_q = e_eta_q + (dydt_eta_q .* y_Xq_int[sel]) * a_beta[mark];
+          }    
+        }         
       }
-      if (has_assoc_cs[m] == 1) {
+      
+      # etalag
+      if (has_assoc_el[m] == 1) {
+        mark = mark + 1;
+        e_eta_q = e_eta_q + a_beta[mark] * ysep_eta_q_lag;          
+      }  
+      
+      # etaauc
+      if (has_assoc_ea[m] == 1) {
+        vector[nrow_y_Xq] ysep_eta_q_auc_tmp;  
+        mark = mark + 1;
+        for (r in 1:nrow_y_Xq) {
+          vector[auc_quadnodes] val_tmp;
+          vector[auc_quadnodes] wgt_tmp;
+          val_tmp = ysep_eta_q_auc[((r-1) * auc_quadnodes + 1):(r * auc_quadnodes)];
+          wgt_tmp = auc_quadweight[((r-1) * auc_quadnodes + 1):(r * auc_quadnodes)];
+          ysep_eta_q_auc_tmp[r] = sum(wgt_tmp .* val_tmp);
+        }
+        e_eta_q = e_eta_q + a_beta[mark] * ysep_eta_q_auc_tmp;          
+      }       
+      
+      # muvalue and any interactions
+      mark2 = mark2 + 1;
+      if (has_assoc_mv[m] == 1) {
+        mark = mark + 1;
+        e_eta_q = e_eta_q + a_beta[mark] * ysep_q; 
+      }
+      if (has_assoc_mvi[m] == 1) {
+  	    int tmp;
+  	    int j_shift;
+  	    if (mark2 == 1) j_shift = 0;
+  	    else j_shift = sum(a_K_int[1:(mark2-1)]);
+  	    tmp = a_K_int[mark2];  
+        for (j in 1:tmp) {
+          int sel;
+          sel = j_shift + j;
+          mark = mark + 1;
+          e_eta_q = e_eta_q + (ysep_q .* y_Xq_int[sel]) * a_beta[mark];
+        }      
+      }     
+
+      # muslope and any interactions
+      mark2 = mark2 + 1;
+      if ((has_assoc_es[m] == 1) || (has_assoc_esi[m] == 1)) {
         vector[nrow_y_Xq] dydt_q;
         dydt_q = (ysep_q_eps - ysep_q) / eps;
+        if (has_assoc_ms[m] == 1) {
+          mark = mark + 1;
+          e_eta_q = e_eta_q + a_beta[mark] * dydt_q;          
+        }
+        if (has_assoc_msi[m] == 1) {
+    	    int tmp;
+    	    int j_shift;
+    	    if (mark2 == 1) j_shift = 0;
+    	    else j_shift = sum(a_K_int[1:(mark2-1)]);
+    	    tmp = a_K_int[mark2];  
+          for (j in 1:tmp) {
+            int sel;
+            sel = j_shift + j;
+            mark = mark + 1;
+            e_eta_q = e_eta_q + (dydt_q .* y_Xq_int[sel]) * a_beta[mark];
+          }          
+        } 
+      }
+      
+      # mulag
+      if (has_assoc_ml[m] == 1) {
         mark = mark + 1;
-        e_eta_q = e_eta_q + a_beta[mark] * dydt_q;          
-      }	
+        e_eta_q = e_eta_q + a_beta[mark] * ysep_q_lag;          
+      }
+
+      # muauc
+      if (has_assoc_ma[m] == 1) {
+        vector[nrow_y_Xq] ysep_q_auc_tmp;  
+        mark = mark + 1;
+        for (r in 1:nrow_y_Xq) {
+          vector[auc_quadnodes] val_tmp;
+          vector[auc_quadnodes] wgt_tmp;
+          val_tmp = ysep_q_auc[((r-1) * auc_quadnodes + 1):(r * auc_quadnodes)];
+          wgt_tmp = auc_quadweight[((r-1) * auc_quadnodes + 1):(r * auc_quadnodes)];
+          ysep_q_auc_tmp[r] = sum(wgt_tmp .* val_tmp);
+        }
+        e_eta_q = e_eta_q + a_beta[mark] * ysep_q_auc_tmp;          
+      }  
+
     }
+    
+    # shared random effects
   	if (sum_size_which_b > 0) {
   	  int mark_beg;  // used to define segment of a_beta
   	  int mark_end;
@@ -1373,13 +1619,13 @@ transformed parameters {
   // Calculate log hazard at event times and unstandardised quadrature points 
   // NB assumes Weibull baseline hazard
   if (basehaz_weibull == 1) 
-    log_basehaz = log(weibull_shape[1]) + (weibull_shape[1] - 1) * e_log_times;
+	  log_basehaz = log(weibull_shape[1]) + (weibull_shape[1] - 1) * e_log_times;
   // NB assumes B-splines baseline hazard
   else if (basehaz_bs == 1)
-    log_basehaz = e_ns_times * bs_coefs;	
+	  log_basehaz = e_ns_times * bs_coefs;	
   // NB assumes piecewise constant baseline hazard
   else if (basehaz_piecewise == 1)
-    log_basehaz = e_times_piecedummy * piecewise_coefs;		  
+	  log_basehaz = e_times_piecedummy * piecewise_coefs;		  
   ll_haz_q = e_d .* (log_basehaz + e_eta_q);
 					  
   // Partition event times and quad points
@@ -1388,7 +1634,7 @@ transformed parameters {
 
   // Log survival contribution to the likelihood (by summing over the 
   //   quadrature points to get the approximate integral) 
-  ll_surv_eventtime = quadweight_times_half_eventtime .* exp(ll_haz_quadtime);        
+  ll_surv_eventtime = quadweight .* exp(ll_haz_quadtime);        
 
   // Log likelihood for event model
   if (has_weights == 0) {  # unweighted log likelihood
@@ -1402,6 +1648,7 @@ transformed parameters {
   ll_event = sum_ll_haz_eventtime - sum_ll_surv_eventtime;				  
 
 }
+
 model {
   int disp_mark;
   int nois_mark;
@@ -1417,7 +1664,7 @@ model {
   int_markun = 1;
   int_marklo = 1;
   int_markup = 1;
-
+  
   // Longitudinal submodel(s): regression equations
 
   if (sum_y_K > 0) y_eta = y_X * y_beta;
@@ -1469,33 +1716,33 @@ model {
         target += GammaReg(y_real[y_real_beg[m]:y_real_end[m]], y_eta_tmp, y_dispersion[disp_mark], link[m], sum_log_y[m]);
       }
       else if (family[m] == 3) {
-	    vector[y_N[m]] sqrt_y_tmp;
-		sqrt_y_tmp = sqrt_y[y_real_beg[m]:y_real_end[m]]; 
+	      vector[y_N[m]] sqrt_y_tmp;
+		    sqrt_y_tmp = sqrt_y[y_real_beg[m]:y_real_end[m]]; 
         target += inv_gaussian(y_real[y_real_beg[m]:y_real_end[m]], 
                                linkinv_inv_gaussian(y_eta_tmp, link[m]), 
                                y_dispersion[disp_mark], sum_log_y[m], sqrt_y_tmp);
       }
 	    else if (family[m] == 4) {
-		  vector[y_N01[m,1]] y_eta0_tmp;
-		  vector[y_N01[m,2]] y_eta1_tmp;
+		    vector[y_N01[m,1]] y_eta0_tmp;
+		    vector[y_N01[m,2]] y_eta1_tmp;
 	      real dummy;  // irrelevant but useful for testing
-		  y_eta0_tmp = segment(y_eta_tmp, 1, y_N01[m,1]);
-		  y_eta1_tmp = segment(y_eta_tmp, (y_N01[m,1] + 1), y_N01[m,2]);
+		    y_eta0_tmp = segment(y_eta_tmp, 1, y_N01[m,1]);
+		    y_eta1_tmp = segment(y_eta_tmp, (y_N01[m,1] + 1), y_N01[m,2]);
 	      dummy = ll_bern_lp(y_eta0_tmp, y_eta1_tmp, link[m], y_N01[m,]);	  
 	    }
 	    else if (family[m] == 5) {
-		  int trials_tmp[y_N[m]];		
+		    int trials_tmp[y_N[m]];		
 	      real dummy;  // irrelevant but useful for testing
-		  trials_tmp = trials[y_beg[m]:y_end[m]];
-          dummy = ll_binom_lp(y_int[y_int_beg[m]:y_int_end[m]], trials_tmp, y_eta_tmp, link[m]);	  
+		    trials_tmp = trials[y_beg[m]:y_end[m]];
+        dummy = ll_binom_lp(y_int[y_int_beg[m]:y_int_end[m]], trials_tmp, y_eta_tmp, link[m]);	  
 	    }
 	    else if (family[m] == 6 || family[m] == 8) {
-          if (link[m] == 1) target += poisson_log_lpmf(y_int[y_int_beg[m]:y_int_end[m]] | y_eta_tmp);
-          else target += poisson_lpmf(y_int[y_int_beg[m]:y_int_end[m]] | linkinv_count(y_eta_tmp, link[m]));
+        if (link[m] == 1) target += poisson_log_lpmf(y_int[y_int_beg[m]:y_int_end[m]] | y_eta_tmp);
+        else target += poisson_lpmf(y_int[y_int_beg[m]:y_int_end[m]] | linkinv_count(y_eta_tmp, link[m]));
 	    }
 	    else if (family[m] == 7) {
-  	      if (link[m] == 1) target += neg_binomial_2_log_lpmf(y_int[y_int_beg[m]:y_int_end[m]] | y_eta_tmp, y_dispersion[disp_mark]);
-          else target += neg_binomial_2_lpmf(y_int[y_int_beg[m]:y_int_end[m]] | 
+  	    if (link[m] == 1) target += neg_binomial_2_log_lpmf(y_int[y_int_beg[m]:y_int_end[m]] | y_eta_tmp, y_dispersion[disp_mark]);
+        else target += neg_binomial_2_lpmf(y_int[y_int_beg[m]:y_int_end[m]] | 
                                            linkinv_count(y_eta_tmp, link[m]), y_dispersion[disp_mark]);
 	    }	    
     }    
@@ -1514,27 +1761,27 @@ model {
   	  else if (family[m] == 3) {
   	    vector[y_N[m]] log_y_tmp;	  
   	    vector[y_N[m]] sqrt_y_tmp;  	    
-    	log_y_tmp = log_y[y_beg[m]:y_end[m]];
-    	sqrt_y_tmp = sqrt_y[y_beg[m]:y_end[m]];
+    		log_y_tmp = log_y[y_beg[m]:y_end[m]];
+    		sqrt_y_tmp = sqrt_y[y_beg[m]:y_end[m]];
   	    summands = pw_inv_gaussian(y_real[y_real_beg[m]:y_real_end[m]], y_eta_tmp, y_dispersion[disp_mark], 
   		                           link[m], log_y_tmp, sqrt_y_tmp);
   	    target += dot_product(y_weights_tmp, summands);
   	  }
-	  else if (family[m] == 4) {
-    	vector[y_N01[m,1]] y_weights0_tmp;
-    	vector[y_N01[m,2]] y_weights1_tmp;
-    	vector[y_N01[m,1]] y_eta0_tmp;
-    	vector[y_N01[m,2]] y_eta1_tmp;
-    	y_eta0_tmp = segment(y_eta_tmp, 1, y_N01[m,1]);
-    	y_eta1_tmp = segment(y_eta_tmp, (y_N01[m,1] + 1), y_N01[m,2]);
-    	y_weights0_tmp = segment(y_weights_tmp, 1, y_N01[m,1]);
-    	y_weights1_tmp = segment(y_weights_tmp, (y_N01[m,1] + 1), y_N01[m,2]);		
+	    else if (family[m] == 4) {
+    		vector[y_N01[m,1]] y_weights0_tmp;
+    		vector[y_N01[m,2]] y_weights1_tmp;
+    		vector[y_N01[m,1]] y_eta0_tmp;
+    		vector[y_N01[m,2]] y_eta1_tmp;
+    		y_eta0_tmp = segment(y_eta_tmp, 1, y_N01[m,1]);
+    		y_eta1_tmp = segment(y_eta_tmp, (y_N01[m,1] + 1), y_N01[m,2]);
+    		y_weights0_tmp = segment(y_weights_tmp, 1, y_N01[m,1]);
+    		y_weights1_tmp = segment(y_weights_tmp, (y_N01[m,1] + 1), y_N01[m,2]);		
         target += dot_product(y_weights0_tmp, pw_bern(0, y_eta0_tmp, link[m]));
         target += dot_product(y_weights1_tmp, pw_bern(1, y_eta1_tmp, link[m]));
   	  }
   	  else if (family[m] == 5) {
-        int trials_tmp[y_N[m]];		
-    	trials_tmp = trials[y_beg[m]:y_end[m]];
+    		int trials_tmp[y_N[m]];		
+    		trials_tmp = trials[y_beg[m]:y_end[m]];
         target += dot_product(y_weights_tmp, 
   		                      pw_binom(y_int[y_int_beg[m]:y_int_end[m]], trials_tmp, y_eta_tmp, link[m]));
   	  }
@@ -1623,7 +1870,7 @@ model {
     int_mark = int_mark + 1;  
     }
   }
-  
+       
   // Log-priors for coefficients in event submodel
   if (priorEvent_dist == 1) e_z_beta ~ normal(0, 1);
   else if (priorEvent_dist == 2) {


### PR DESCRIPTION
Changed default priors for baseline hazard coefficients and association
parameters so they are much less constraining. They now use SD of 50 for
basehaz coefficients, and SD of 25 for association parameters. In the
future, could potentially think about scaling them depending on the
data, rather than using vague priors.

Have also added the following association structures:
(1) lagged effects
(2) cumulative effects (area under the marker trajectory)
(3) interactions between variables in dataLong and any of the other
association structure quantities (etavalue, muvalue, etaslope, etc)

Note the following for the association structures:
For (1)... For lagged values of the marker that correspond to a time
earlier than baseline, the baseline marker value is assumed to apply.
For (3)... At the moment the data must be contained in the dataframe
used for the
covariates in the longitudinal submodel. However I have also added an
argument to stan_jm that allows the user to specify "interaction_data",
which could be a data frame that contains the covariates but using a
different measurement time schedule to the data frame passed to
dataLong. This would provide greater flexibility. The "interaction_data"
argument isn't properly implemented yet though.