### PR TITLE
Bug fix, for multivariate JM with etavalue assoc

### DIFF
--- a/R/stan_jm.R
+++ b/R/stan_jm.R
@@ -481,8 +481,8 @@ stan_jm <- function(formulaLong, dataLong, formulaEvent, dataEvent, time_var,
   mc$time_var <- mc$id_var <- mc$assoc <- 
     mc$basehaz <- mc$basehaz_ops <-
     mc$df <- mc$knots <- mc$quadnodes <- NULL
-  mc$priorLong <- mc$priorLong_intercept <- 
-    mc$priorEvent <- mc$priorEvent_intercept <-
+  mc$priorLong <- mc$priorLong_intercept <- mc$priorLong_aux <-
+    mc$priorEvent <- mc$priorEvent_intercept <- mc$priorEvent_aux <-
     mc$priorAssoc <- mc$prior_covariance <-
     mc$prior_PD <- mc$algorithm <- mc$scale <- 
     mc$concentration <- mc$shape <- mc$init <- 

--- a/exec/jm.stan
+++ b/exec/jm.stan
@@ -485,7 +485,7 @@ transformed parameters {
       mark2 = mark2 + 1; // count even if assoc type isn't used
       if (has_assoc[1,m] == 1) { # etavalue
         mark = mark + 1;
-	      e_eta_q = e_eta_q + a_beta[mark] * y_eta_qwide[M];
+	      e_eta_q = e_eta_q + a_beta[mark] * y_eta_qwide[m];
       }	
       if (has_assoc[11,m] == 1) { # etavalue*data
   	    int tmp;


### PR DESCRIPTION
Inside one of the (m in 1:M) loops in jm.stan, the indexing for the
etavalue assoc was M instead of m, which meant the etavalue for one
submodel was repeated M times!! Should now correctly loop over the
etavalues for each of the submodels.

Also using prior*_aux was throwing error, since wasn't being set to NULL
in matched call.