### PR TITLE
Set cumulative hazard equal to zero where last known survival time is time zero

### DIFF
--- a/R/misc.R
+++ b/R/misc.R
@@ -1188,13 +1188,14 @@ jm_data <- function(object, newdataLong = NULL, newdataEvent = NULL,
     qtimes <- unlist(lapply(qq$points,  unstandardise_quadpoints,  0, etimes))
     qwts   <- unlist(lapply(qq$weights, unstandardise_quadweights, 0, etimes))
     edat <- prepare_data_table(ndE, id_var, time_var)
-    edat <- rolling_merge(edat, ids = rep(id_list, qnodes), times = qtimes)
+    times <- c(etimes, qtimes) # times used to design event submodel matrices
+    edat <- rolling_merge(edat, ids = rep(id_list, qnodes + 1), times = times)
     eXq  <- .pp_data_mer_x(object, newdata = edat, m = "Event")       
     assoc_parts <- lapply(1:M, function(m) {
       ymf <- prepare_data_table(ndL[[m]], id_var, time_var)
       make_assoc_parts(
         ymf, assoc = object$assoc, id_var = object$id_var, 
-        time_var = object$time_var, id_list = id_list, times = qtimes, 
+        time_var = object$time_var, id_list = id_list, times = times, 
         use_function = pp_data, object = object, m = m)
     })
     assoc_attr <- nlist(.Data = assoc_parts, qnodes, qtimes, qwts, etimes, estatus)


### PR DESCRIPTION
Set cumulative hazard equal to zero where last known survival time is
time zero. Avoids an error when the quadrature times are all zero (for
an individual) because the event time (or last known survival time is
zero).

Also fixed an error where the event times where not being included in
the times used to generate the event submodel design matrices in
jm_data. This didn't cause any problem for posterior_survfit, because
the event times aren't needed to get survival probabilities. BUT, it did
cause a problem for the log likelihood calculation for the event
submodel, and therefore also for the log likelihood calculation for the
full joint model -- this means that the log_lik method, as well as
loo/WAIC, might have been slightly incorrect. Also, the log likelihood
is used in the MH algorithm for generating new b pars in
posterior_survfit, so this might have also been incorrect.